### PR TITLE
fix: agregue la opción de inclusión para categoría en la consulta fin…

### DIFF
--- a/src/infraestructure/persistence/galaxia/galaxia.prisma.repository.ts
+++ b/src/infraestructure/persistence/galaxia/galaxia.prisma.repository.ts
@@ -101,7 +101,9 @@ export class GalaxiaPrismaRepository implements GalaxiaRepository {
       skip: (page - 1) * limit,
       take: limit,
       where: { estado: true, ...(categoriaId && { categoriaId: categoriaId }) },
-
+       include:{
+        categoria:true
+      },
       orderBy: { fechaCreacion: 'desc' },
     });
     // Validar si no hay resultados


### PR DESCRIPTION
Se ajustó el endpoint GET /genListasOpciones para que ahora incluya los campos que antes no se visualizaban en la respuesta.

Cambios principales:

Se corrigió la consulta del servicio para traer todos los datos de la categoría asociados a cada opción.

Ahora la respuesta del GET expone correctamente los atributos adicionales que estaban ocultos o no mapeados.

Se mantiene la paginación y filtros existentes, pero enriqueciendo los datos con la información de la categoría relacionada.