### PR TITLE
Feature/completar request body en swagger edwinw

### DIFF
--- a/src/application/dto/categoria/create-categoria.dto.ts
+++ b/src/application/dto/categoria/create-categoria.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import {
   IsBoolean,
@@ -9,44 +10,96 @@ import {
 } from 'class-validator';
 
 export class CreateCategoriaDto {
+  @ApiProperty({
+    example: 'Niños',
+    description: 'Nombre de la categoría (solo se permiten 3 categorías: NIÑOS, JÓVENES, ADULTOS)',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   nombre: string;
 
+  @ApiProperty({
+    example: 'Categoría para contenido educativo dirigido a niños',
+    description: 'Descripción de la categoría',
+    required: false,
+  })
   @IsOptional()
   descripcion: string;
 
+  @ApiProperty({
+    example: true,
+    description: 'Estado de la categoría (activo/inactivo)',
+    required: false,
+    default: true,
+  })
   @IsOptional()
   @IsBoolean()
   estado: boolean;
 
+  @ApiProperty({
+    example: '2025-10-01T10:30:00.000Z',
+    description: 'Fecha de creación de la categoría',
+    type: Date,
+    required: false,
+  })
   @IsDate()
   @IsOptional()
   @Type(() => Date)
   fechaCreacion: Date;
 
+  @ApiProperty({
+    example: '2025-10-01T10:30:00.000Z',
+    description: 'Fecha de última actualización de la categoría',
+    type: Date,
+    required: false,
+  })
   @IsDate()
   @IsOptional()
   @Type(() => Date)
   fechaActualizacion: Date;
 
+  @ApiProperty({
+    example: 0,
+    description: 'Coordenada X en el espacio 3D del universo',
+    required: false,
+  })
   @IsOptional()
   @IsNumber()
   x?: number;
 
+  @ApiProperty({
+    example: 5,
+    description: 'Coordenada Y en el espacio 3D del universo',
+    required: false,
+  })
   @IsOptional()
   @IsNumber()
   y?: number;
 
+  @ApiProperty({
+    example: -10,
+    description: 'Coordenada Z en el espacio 3D del universo',
+    required: false,
+  })
   @IsOptional()
   @IsNumber()
   z?: number;
 
+  @ApiProperty({
+    example: 'https://png.pngtree.com/png-vector/20241018/ourmid/pngtree-3d-class-tripp-happy-children-with-white-background-png-image_14109691.png',
+    description: 'URL de la categoría',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   url?: string;
 
+  @ApiProperty({
+    example: '/assets/cohete/scene.gltf',
+    description: 'Nombre del archivo del modelo 3D de la categoría',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   modelo?: string;

--- a/src/application/dto/categoria/update-categoria.dto.ts
+++ b/src/application/dto/categoria/update-categoria.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateCategoriaDto } from './create-categoria.dto';
 
 export class UpdateCategoriaDto extends PartialType(CreateCategoriaDto) {}

--- a/src/application/dto/curso/update-curso.dto.ts
+++ b/src/application/dto/curso/update-curso.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateCursoDto } from './create-curso.dto';
 
 export class UpdateCursoDto extends PartialType(CreateCursoDto) {}

--- a/src/application/dto/galaxia/create-galaxia.dto.ts
+++ b/src/application/dto/galaxia/create-galaxia.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import {
   IsBoolean,
@@ -10,53 +11,118 @@ import {
 import { Vector3Dto } from './vector/vector-galaxia.dto';
 
 export class CreateGalaxiaDto {
+  @ApiProperty({
+    example: 'Salud Emocional',
+    description: 'Nombre de la galaxia',
+    required: true,
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   nombre: string;
 
+  @ApiProperty({
+    example: 'Galaxia dedicada al aprendizaje sobre salud emocional y bienestar mental',
+    description: 'Descripción detallada de la galaxia',
+    required: true,
+  })
   @IsString()
   @IsNotEmpty()
   descripcion: string;
 
+  @ApiProperty({
+    example: 'null',
+    description: 'URL de la imagen de la galaxia',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   imagen?: string;
 
+  @ApiProperty({
+    example: 'https://example.com/salud-emocional',
+    description: 'URL relacionada con la galaxia',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   url?: string;
 
+  @ApiProperty({
+    example: 'salud-emocional-textura.png',
+    description: 'Nombre del archivo de textura para renderizado 3D',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   textura?: string;
 
+  @ApiProperty({
+    example: true,
+    description: 'Estado de la galaxia (activo/inactivo)',
+    required: false,
+    default: true,
+  })
   @IsBoolean()
   @IsOptional()
   estado: boolean;
 
+  @ApiProperty({
+    example: '2025-10-01T10:30:00.000Z',
+    description: 'Fecha de creación de la galaxia',
+    required: false,
+    type: Date,
+  })
   @IsDate()
   @IsOptional()
   @Type(() => Date)
   fechaCreacion?: Date;
 
+  @ApiProperty({
+    example: '2025-10-01T10:30:00.000Z',
+    description: 'Fecha de última actualización de la galaxia',
+    required: false,
+    type: Date,
+  })
   @IsDate()
   @IsOptional()
   @Type(() => Date)
   fechaActualizacion?: Date;
 
+  @ApiProperty({
+    example: '689e130abb9772d4bb7b983f',
+    description: 'ID de la categoría a la que pertenece la galaxia (ObjectId de MongoDB)',
+    required: true,
+  })
   @IsMongoId({ message: 'El campo categoriaId debe ser un ID de Mongo válido' })
   @IsNotEmpty({ message: 'La categoría es obligatoria' })
   categoriaId: string;
 
+  @ApiProperty({
+    example: '#FE797B',
+    description: 'Color de la galaxia en formato hexadecimal',
+    required: true,
+  })
   @IsString()
   @IsNotEmpty()
   color: string;
 
+  @ApiProperty({
+    example: { x: -13, y: 1, z: 3 },
+    description: 'Posición de la galaxia en el espacio 3D (coordenadas x, y, z)',
+    required: false,
+    type: Vector3Dto,
+  })
   @IsOptional()
   @Type(() => Vector3Dto)
   posicion?: Vector3Dto;
 
+  @ApiProperty({
+    example: { x: 1.847995880179171, y: 0, z: 5 },
+    description: 'Rotación de la galaxia en el espacio 3D (ángulos en radianes x, y, z)',
+    required: false,
+    type: Vector3Dto,
+  })
   @IsOptional()
   @Type(() => Vector3Dto)
   rotacion?: Vector3Dto;

--- a/src/application/dto/galaxia/update-galaxia.dto.ts
+++ b/src/application/dto/galaxia/update-galaxia.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateGalaxiaDto } from './create-galaxia.dto';
 
 export class UpdateGalaxiaDto extends PartialType(CreateGalaxiaDto) {}

--- a/src/application/dto/idioma/create-idioma.dto.ts
+++ b/src/application/dto/idioma/create-idioma.dto.ts
@@ -1,12 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsNotEmpty, IsString, IsOptional, IsBoolean } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateIdiomaDto {
+  @ApiProperty({
+    example: 'Español',
+    description: 'Nombre del idioma',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   nombre: string;
 
+  @ApiProperty({
+    example: true,
+    description: 'Estado del idioma (activo/inactivo)',
+    required: false,
+    default: true,
+  })
   @IsOptional()
   @IsBoolean()
   estado: boolean;

--- a/src/application/dto/idioma/update-idioma.dto.ts
+++ b/src/application/dto/idioma/update-idioma.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateIdiomaDto } from './create-idioma.dto';
 
 export class UpdateIdiomaDto extends PartialType(CreateIdiomaDto) {}

--- a/src/application/dto/lading-page/update-landing-page.dto.ts
+++ b/src/application/dto/lading-page/update-landing-page.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateLandingPageDto } from "./create-landing-page.dto";
+import { PartialType } from '@nestjs/swagger';
+import { CreateLandingPageDto } from './create-landing-page.dto';
 
 export class UpdateLandingPageDto extends PartialType(CreateLandingPageDto) {}

--- a/src/application/dto/menu/create-menu.dto.ts
+++ b/src/application/dto/menu/create-menu.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsArray,
@@ -8,42 +9,93 @@ import {
 } from 'class-validator';
 
 export class CreateSubMenuDto {
+  @ApiProperty({
+    example: 'Crear Nuevo Curso',
+    description: 'Nombre del submenú',
+  })
   @IsString()
   @IsNotEmpty()
   nombre: string;
 
+  @ApiProperty({
+    example: 'ninos/crear',
+    description: 'Ruta de navegación del submenú',
+  })
   @IsString()
   @IsNotEmpty()
   ruta: string;
 
+  @ApiProperty({
+    example: 'pi pi-save',
+    description: 'Nombre del icono del submenú',
+  })
   @IsString()
   @IsNotEmpty()
   icono: string;
 
+  @ApiProperty({
+    example: '#fff',
+    description: 'Color del submenú en formato hexadecimal',
+  })
   @IsString()
   @IsNotEmpty()
   color: string;
 }
 
 export class CreateMenuDto {
+  @ApiProperty({
+    example: 'Cursos',
+    description: 'Nombre del menú principal',
+  })
   @IsString()
   @IsNotEmpty()
   nombre: string;
 
+  @ApiProperty({
+    example: '/cursos',
+    description: 'Ruta de navegación del menú principal',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   ruta: string;
 
+  @ApiProperty({
+    example: 'pi pi-book',
+    description: 'Nombre del icono del menú principal',
+  })
   @IsString()
   @IsNotEmpty()
   icono: string;
 
+  @ApiProperty({
+    example: '#222',
+    description: 'Color del menú principal en formato hexadecimal',
+  })
   @IsString()
   @IsNotEmpty()
   color: string;
 
+  @ApiProperty({
+    example: [
+      {
+        nombre: 'Nuevo Curso',
+        ruta: '/nuevo-curso',
+        icono: 'book',
+        color: '#fff',
+      },
+      {
+        nombre: 'Progreso',
+        ruta: '/progreso',
+        icono: 'chart',
+        color: '#222',
+      },
+    ],
+    description: 'Array de submenús',
+    type: [CreateSubMenuDto],
+  })
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => CreateSubMenuDto) 
-  subMenu: CreateSubMenuDto[]; 
+  @Type(() => CreateSubMenuDto)
+  subMenu: CreateSubMenuDto[];
 }

--- a/src/application/dto/menu/update-menu.dto.ts
+++ b/src/application/dto/menu/update-menu.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateMenuDto } from './create-menu.dto';
 import { EstadoGenerico } from '@prisma/client';
 import { IsEnum } from 'class-validator';

--- a/src/application/dto/planeta/beneficio/beneficioDto.ts
+++ b/src/application/dto/planeta/beneficio/beneficioDto.ts
@@ -1,17 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
 import { Transform } from 'class-transformer';
 
-const trim = ({ value }: { value: any }) =>
-  typeof value === 'string' ? value.trim() : value;
-
 export class BeneficioDto {
+  @ApiProperty({
+    example: 'Aprenderás a manejar conflictos',
+    description: 'Título del beneficio del planeta',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   titulo: string;
 
+  @ApiProperty({
+    example: 'Desarrollarás habilidades de comunicación asertiva para resolver conflictos de manera efectiva',
+    description: 'Descripción detallada del beneficio',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   descripcion: string;
 }

--- a/src/application/dto/planeta/create-planeta.dto.ts
+++ b/src/application/dto/planeta/create-planeta.dto.ts
@@ -1,101 +1,197 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import {
+  IsArray,
   IsDate,
+  IsEnum,
   IsMongoId,
   IsNotEmpty,
   IsOptional,
   IsString,
   ValidateNested,
-  IsArray,
-  IsEnum,
 } from 'class-validator';
 import { InfoPlanetaDto } from './Informacion/infoPlanetaDto';
 import { PeligroDto } from './Peligros/peligroDto';
 import { BeneficioDto } from './Beneficio/beneficioDto';
 import { EstadoGenerico } from '@prisma/client';
 
-const trim = ({ value }: { value: any }) =>
-  typeof value === 'string' ? value.trim() : value;
-
 export class CreatePlanetaDto {
+  @ApiProperty({
+    example: 'Planeta de Comunicación Asertiva',
+    description: 'Nombre del planeta',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   nombre: string;
 
+  @ApiProperty({
+    example: 'NIÑOS',
+    description: 'Grupo al que pertenece el planeta',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   grupo: string;
 
+  @ApiProperty({
+    example: 'Calmito el mejor',
+    description: 'Nombre específico del planeta en el universo',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   planetaNombre: string;
 
+  @ApiProperty({
+    example: 'SALUD_MENTAL',
+    description: 'Tema principal del planeta',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   tema: string;
 
+  @ApiProperty({
+    example: '/assets/2k_neptune.jpg',
+    description: 'Nombre del archivo de textura para renderizado 3D',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   textura: string;
 
+  @ApiProperty({
+    example: '/galaxia/ninos/salud-mental/calmito',
+    description: 'URL del planeta',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   url: string;
 
+  @ApiProperty({
+    example: 'https://images.unsplash.com/photo-1581822261290-991b38693d1b?fm=jpg&q=60&w=3000&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Nnx8YXN0cm9uYXV0fGVufDB8fDB8fHww',
+    description: 'URL de la imagen de resumen del planeta',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   imagenResumen: string;
 
+  @ApiProperty({
+    example: 'https://tn.com.ar/resizer/v2/cual-es-el-sueldo-de-un-astronauta-de-la-nasa-foto-adobestock-OVP5HZHY7NHB3PWLAVL5ARG66A.png?auth=a3e77c7ff1be7c62dfc79ca3276dbc43d99ec81620644ed5637f4993c154dad4&width=767',
+    description: 'URL de la imagen de beneficios del planeta',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   imagenBeneficios: string;
 
+  @ApiProperty({
+    example: 'Este curso te llevará a través de los conceptos básicos y avanzados del planeta Kio, explorando: Geografía única, clima extremo y desafíos tecnológicos.',
+    description: 'Resumen del curso del planeta',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   resumenCurso: string;
 
+  @ApiProperty({
+    example: 'ACTIVO',
+    description: 'Estado del planeta',
+    enum: EstadoGenerico,
+    required: false,
+  })
   @IsEnum(EstadoGenerico, {
     message: `El estado debe ser uno de los siguientes valores: ${Object.values(EstadoGenerico).join(', ')}`,
   })
   @IsOptional()
   estado?: EstadoGenerico;
 
+  @ApiProperty({
+    example: {
+      tipoRiesgo: 'Conflicto interpersonal',
+      tamano: 'Mediano',
+      composicion: 'Rocoso con atmósfera densa',
+      riesgo: 'Alto - Requiere habilidades de comunicación',
+      nivel: 'Intermedio',
+      ambiente: 'Tenso y desafiante',
+      temperatura: 'Caliente',
+      villano: 'La Ira',
+    },
+    description: 'Información detallada del planeta',
+    type: InfoPlanetaDto,
+  })
   @ValidateNested()
   @Type(() => InfoPlanetaDto)
   @IsNotEmpty()
   info: InfoPlanetaDto;
 
+  @ApiProperty({
+    example: [
+      {
+        nombre: 'Conflictos no resueltos',
+        descripcion: 'Situaciones de tensión que pueden escalar',
+        nivelRiesgo: 'Alto',
+        temperatura: 'Caliente',
+        villano: 'La Ira',
+        cta: 'Aprende a manejar tus emociones',
+      },
+    ],
+    description: 'Lista de peligros del planeta',
+    type: [PeligroDto],
+    required: false,
+  })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => PeligroDto)
   @IsOptional()
   peligros?: PeligroDto[];
 
+  @ApiProperty({
+    example: [
+      {
+        titulo: 'Aprenderás a manejar conflictos',
+        descripcion: 'Desarrollarás habilidades de comunicación asertiva',
+      },
+    ],
+    description: 'Lista de beneficios del planeta',
+    type: [BeneficioDto],
+    required: false,
+  })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => BeneficioDto)
   @IsOptional()
   beneficios?: BeneficioDto[];
 
+  @ApiProperty({
+    example: '2025-10-01T10:30:00.000Z',
+    description: 'Fecha de creación del planeta',
+    type: Date,
+    required: false,
+  })
   @IsDate()
   @IsOptional()
   @Type(() => Date)
   fechaCreacion?: Date;
 
+  @ApiProperty({
+    example: '2025-10-01T10:30:00.000Z',
+    description: 'Fecha de última actualización del planeta',
+    type: Date,
+    required: false,
+  })
   @IsDate()
   @IsOptional()
   @Type(() => Date)
   fechaActualizacion?: Date;
 
+  @ApiProperty({
+    example: '64f27cdb7b97a2e89f2f7c12',
+    description: 'ID de la galaxia a la que pertenece el planeta (ObjectId de MongoDB)',
+  })
   @IsMongoId({ message: 'El campo GalaxiaId debe ser un ID de Mongo válido' })
   @IsNotEmpty({ message: 'La Galaxia es obligatoria' })
   galaxiaId: string;

--- a/src/application/dto/planeta/informacion/InfoPlanetaDto.ts
+++ b/src/application/dto/planeta/informacion/InfoPlanetaDto.ts
@@ -1,42 +1,75 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class InfoPlanetaDto {
+  @ApiProperty({
+    example: 'Conflicto interpersonal',
+    description: 'Tipo de riesgo del planeta',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   tipoRiesgo: string;
 
+  @ApiProperty({
+    example: 'Mediano',
+    description: 'Tamaño del planeta',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   tamano: string;
 
+  @ApiProperty({
+    example: 'Rocoso con atmósfera densa',
+    description: 'Composición del planeta',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   composicion: string;
 
+  @ApiProperty({
+    example: 'Alto - Requiere habilidades de comunicación',
+    description: 'Descripción del nivel de riesgo',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   riesgo: string;
 
+  @ApiProperty({
+    example: 'Intermedio',
+    description: 'Nivel de dificultad del planeta',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   nivel: string;
 
+  @ApiProperty({
+    example: 'Tenso y desafiante',
+    description: 'Ambiente del planeta',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   ambiente: string;
 
+  @ApiProperty({
+    example: 'Caliente',
+    description: 'Temperatura del planeta',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())
   temperatura: string;
 
+  @ApiProperty({
+    example: 'La Ira',
+    description: 'Villano principal del planeta',
+  })
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value.trim())

--- a/src/application/dto/planeta/peligros/peligroDto.ts
+++ b/src/application/dto/planeta/peligros/peligroDto.ts
@@ -1,37 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { Transform } from 'class-transformer';
 
-const trim = ({ value }: { value: any }) =>
-  typeof value === 'string' ? value.trim() : value;
-
 export class PeligroDto {
+  @ApiProperty({
+    example: 'Conflictos no resueltos',
+    description: 'Nombre del peligro',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   nombre: string;
 
+  @ApiProperty({
+    example: 'Situaciones de tensión que pueden escalar si no se manejan adecuadamente',
+    description: 'Descripción detallada del peligro',
+  })
   @IsString()
   @IsNotEmpty()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   descripcion: string;
 
+  @ApiProperty({
+    example: 'Alto',
+    description: 'Nivel de riesgo del peligro',
+    required: false,
+  })
   @IsString()
   @IsOptional()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   nivelRiesgo?: string;
 
+  @ApiProperty({
+    example: 'Caliente',
+    description: 'Temperatura asociada al peligro (metáfora del nivel de conflicto)',
+    required: false,
+  })
   @IsString()
   @IsOptional()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   temperatura?: string;
 
+  @ApiProperty({
+    example: 'La Ira',
+    description: 'Personaje villano asociado al peligro',
+    required: false,
+  })
   @IsString()
   @IsOptional()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   villano?: string;
 
+  @ApiProperty({
+    example: 'Aprende a manejar tus emociones',
+    description: 'Call to Action para superar el peligro',
+    required: false,
+  })
   @IsString()
   @IsOptional()
-  @Transform(trim)
+  @Transform(({ value }) => value?.trim())
   cta?: string;
 }

--- a/src/application/dto/planeta/update-planeta.dto.ts
+++ b/src/application/dto/planeta/update-planeta.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreatePlanetaDto } from './create-planeta.dto';
 
 export class UpdatePlanetaDto extends PartialType(CreatePlanetaDto) {}

--- a/src/application/dto/profesor/update-profesor.dto.ts
+++ b/src/application/dto/profesor/update-profesor.dto.ts
@@ -1,5 +1,5 @@
-import { PartialType } from "@nestjs/mapped-types";
-import { createProfesorDto } from "./create-profesor.dto";
+import { PartialType } from '@nestjs/swagger';
+import { createProfesorDto } from './create-profesor.dto';
 
 
 export class updateProfesorDto extends PartialType(createProfesorDto){

--- a/src/infraestructure/http/curso/cursos.controller.ts
+++ b/src/infraestructure/http/curso/cursos.controller.ts
@@ -1,23 +1,23 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
+  Get,
   HttpException,
   HttpStatus,
+  Param,
+  Patch,
+  Post,
 } from '@nestjs/common';
 
-import { CursosService } from '../../../core/services/curso/cursos.service';
+// import { CursosService } from '../../../core/services/curso/cursos.service';
 import * as useCase from 'src/application/uses-cases/curso';
 import { ParseObjectIdPipe } from 'src/shared/pipes/parse-object-id.pipe';
 import * as dto from 'src/application/dto/curso';
 import * as azureCase from 'src/application/uses-cases/azure';
-import { RequiredFile } from 'src/shared/decorator/required-file.decorator';
+// import { RequiredFile } from 'src/shared/decorator/required-file.decorator';
 import { ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
-import { plainToInstance } from 'class-transformer';
+// import { plainToInstance } from 'class-transformer';
 import { RequestListarCurso } from 'src/shared/enums/request-list-curso-enum';
 @Controller('cursos')
 export class CursosController {
@@ -106,7 +106,7 @@ export class CursosController {
   @Patch(':id')
   @ApiOperation({ summary: 'Actualiza los datos de un curso y cambia o mantiene su estado en true(activo).' })
   @ApiParam({ name: 'id', example: '5f43e9b5e3f1c530d8b6f8a9', description: 'ID del curso.' })
-  @ApiBody({ type: dto.CreateCursoDto })
+  @ApiBody({ type: dto.UpdateCursoDto })
   @ApiResponse({ status: 200, description: 'Curso actualizado correctamente.' })
   @ApiResponse({ status: 404, description: 'No se encontró el curso con el ID proporcionado.' })
   async update(

--- a/src/infraestructure/http/idioma/idioma.controller.ts
+++ b/src/infraestructure/http/idioma/idioma.controller.ts
@@ -1,19 +1,27 @@
 import {
   Body,
   Controller,
+  Delete,
+  Get,
   HttpException,
   HttpStatus,
-  Post,
   Param,
   Patch,
-  Get,
-  Delete,
+  Post,
 } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { CreateIdiomaDto } from 'src/application/dto/idioma/create-idioma.dto';
 import { UpdateIdiomaDto } from 'src/application/dto/idioma';
 import * as useCase from 'src/application/uses-cases/idioma';
 import { ParseObjectIdPipe } from 'src/shared/pipes/parse-object-id.pipe';
 
+@ApiTags('Idiomas')
 @Controller('idioma')
 export class IdiomaController {
   constructor(
@@ -25,10 +33,14 @@ export class IdiomaController {
   ) {}
 
   @Post()
+  @ApiOperation({ summary: 'Crear un nuevo idioma' })
+  @ApiBody({ type: CreateIdiomaDto, description: 'Datos para crear el idioma' })
+  @ApiResponse({ status: 201, description: 'Idioma creado exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
   async create(@Body() createIdiomaDto: CreateIdiomaDto) {
-    
+
     const result = await this.createIdiomaUseCase.execute(createIdiomaDto);
-    
+
     if (result.isFailure) {
       throw new HttpException(result.error.message, HttpStatus.BAD_REQUEST);
     }
@@ -38,20 +50,29 @@ export class IdiomaController {
       message: 'Idioma creado',
     };
   }
+
   @Get()
-    async getAll() {
-      const result = await this.getAllIdiomaUseCase.execute();
-  
-      if (result.isFailure) {
-        throw new HttpException(result.error.message, HttpStatus.BAD_REQUEST);
-      }
-  
-      return {
-        data: result,
-        message: 'Idioma obtenidas',
-      };
+  @ApiOperation({ summary: 'Obtener todos los idiomas' })
+  @ApiResponse({ status: 200, description: 'Lista de idiomas obtenida correctamente' })
+  @ApiResponse({ status: 400, description: 'Error al obtener los idiomas' })
+  async getAll() {
+    const result = await this.getAllIdiomaUseCase.execute();
+
+    if (result.isFailure) {
+      throw new HttpException(result.error.message, HttpStatus.BAD_REQUEST);
     }
-    @Get(':id')
+
+    return {
+      data: result,
+      message: 'Idiomas obtenidos',
+    };
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Obtener un idioma por ID' })
+  @ApiParam({ name: 'id', description: 'ID del idioma', type: String, example: '507f1f77bcf86cd799439011' })
+  @ApiResponse({ status: 200, description: 'Idioma obtenido correctamente' })
+  @ApiResponse({ status: 404, description: 'Idioma no encontrado' })
   async findOne(@Param('id', ParseObjectIdPipe) id: string) {
     const result = await this.GetOnIdiomaUseCase.execute(id);
 
@@ -61,40 +82,51 @@ export class IdiomaController {
 
     return {
       data: result,
-      message: 'Idioma obtenida',
+      message: 'Idioma obtenido',
     };
   }
+
   @Patch(':id')
-    async update(
-      @Param('id', ParseObjectIdPipe) id: string,
-      @Body() updateIdioma: UpdateIdiomaDto,
-    ) {
-      const result = await this.UpdateIdiomaUseCase.execute(
-        id,
-        updateIdioma,
-      );
-  
-      if (result.isFailure) {
-        throw new HttpException(result.error.message, HttpStatus.BAD_REQUEST);
-      }
-  
-      return {
-        data: result,
-        message: 'Idioma ACtulizado',
-      };
+  @ApiOperation({ summary: 'Actualizar un idioma' })
+  @ApiParam({ name: 'id', description: 'ID del idioma', type: String, example: '507f1f77bcf86cd799439011' })
+  @ApiBody({ type: UpdateIdiomaDto, description: 'Datos para actualizar el idioma' })
+  @ApiResponse({ status: 200, description: 'Idioma actualizado correctamente' })
+  @ApiResponse({ status: 404, description: 'Idioma no encontrado' })
+  async update(
+    @Param('id', ParseObjectIdPipe) id: string,
+    @Body() updateIdioma: UpdateIdiomaDto,
+  ) {
+    const result = await this.UpdateIdiomaUseCase.execute(
+      id,
+      updateIdioma,
+    );
+
+    if (result.isFailure) {
+      throw new HttpException(result.error.message, HttpStatus.BAD_REQUEST);
     }
+
+    return {
+      data: result,
+      message: 'Idioma actualizado',
+    };
+  }
+
   @Delete(':id')
-    async remove(@Param('id', ParseObjectIdPipe) id: string) {
-     
-      const result = await this.DeleteIdiomaUseCase.execute(id);
-  
-      if (result.isFailure) {
-        throw new HttpException(result.error.message, HttpStatus.BAD_REQUEST);
-      }
-  
-      return {
-        data: result,
-        message: 'Idioma eliminada',
-      };
+  @ApiOperation({ summary: 'Eliminar un idioma' })
+  @ApiParam({ name: 'id', description: 'ID del idioma', type: String, example: '507f1f77bcf86cd799439011' })
+  @ApiResponse({ status: 200, description: 'Idioma eliminado correctamente' })
+  @ApiResponse({ status: 404, description: 'Idioma no encontrado' })
+  async remove(@Param('id', ParseObjectIdPipe) id: string) {
+
+    const result = await this.DeleteIdiomaUseCase.execute(id);
+
+    if (result.isFailure) {
+      throw new HttpException(result.error.message, HttpStatus.BAD_REQUEST);
     }
+
+    return {
+      data: result,
+      message: 'Idioma eliminado',
+    };
+  }
 }

--- a/src/infraestructure/http/menu/menu.controller.ts
+++ b/src/infraestructure/http/menu/menu.controller.ts
@@ -1,42 +1,69 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
 } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
 import { CreateMenuDto } from 'src/application/dto/menu/create-menu.dto';
 import { UpdateMenuDto } from 'src/application/dto/menu/update-menu.dto';
 import { MenuService } from 'src/core/services/menu/menu.service';
 
+@ApiTags('Menús')
 @Controller('menu')
 export class MenuController {
   constructor(private readonly menuService: MenuService) {}
 
   @Post()
+  @ApiOperation({ summary: 'Crear un nuevo menú' })
+  @ApiBody({ type: CreateMenuDto, description: 'Datos para crear el menú' })
+  @ApiResponse({ status: 201, description: 'Menú creado exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
   create(@Body() createMenuDto: CreateMenuDto) {
     return this.menuService.create(createMenuDto);
   }
 
   @Get()
+  @ApiOperation({ summary: 'Obtener todos los menús' })
+  @ApiResponse({ status: 200, description: 'Lista de menús obtenida correctamente' })
   findAll() {
     return this.menuService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Obtener un menú por ID' })
+  @ApiParam({ name: 'id', description: 'ID del menú', type: String, example: '507f1f77bcf86cd799439011' })
+  @ApiResponse({ status: 200, description: 'Menú obtenido correctamente' })
+  @ApiResponse({ status: 404, description: 'Menú no encontrado' })
   findOne(@Param('id') id: string) {
     return this.menuService.findOne(id);
   }
 
   @Patch(':id')
+  @ApiOperation({ summary: 'Actualizar un menú' })
+  @ApiParam({ name: 'id', description: 'ID del menú', type: String, example: '507f1f77bcf86cd799439011' })
+  @ApiBody({ type: UpdateMenuDto, description: 'Datos para actualizar el menú' })
+  @ApiResponse({ status: 200, description: 'Menú actualizado correctamente' })
+  @ApiResponse({ status: 404, description: 'Menú no encontrado' })
   update(@Param('id') id: string, @Body() updateMenuDto: UpdateMenuDto) {
     return this.menuService.update(id, updateMenuDto);
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Eliminar un menú' })
+  @ApiParam({ name: 'id', description: 'ID del menú', type: String, example: '507f1f77bcf86cd799439011' })
+  @ApiResponse({ status: 200, description: 'Menú eliminado correctamente' })
+  @ApiResponse({ status: 404, description: 'Menú no encontrado' })
   remove(@Param('id') id: string) {
     return this.menuService.remove(id);
   }

--- a/src/infraestructure/http/planeta/planetas.controller.ts
+++ b/src/infraestructure/http/planeta/planetas.controller.ts
@@ -16,12 +16,14 @@ import {
   ApiParam,
   ApiQuery,
   ApiResponse,
+  ApiTags,
 } from '@nestjs/swagger';
 import * as dto from 'src/application/dto/planeta/';
 import { PlanetaPaginationDto } from 'src/application/dto/planeta/PlanetaPagination.dto';
 import * as useCase from 'src/application/uses-cases/planeta';
 import { ParseObjectIdPipe } from 'src/shared/pipes/parse-object-id.pipe';
 
+@ApiTags('Planetas')
 @Controller('planetas')
 export class planetasController {
   constructor(

--- a/src/infraestructure/http/profesor/profesor.controller.ts
+++ b/src/infraestructure/http/profesor/profesor.controller.ts
@@ -91,7 +91,7 @@ export class ProfesorController {
       @Patch(':id')
       @ApiOperation({ summary: 'Actualiza los datos de un Profesor y cambia o mantiene su estado en true(activo).' })
       @ApiParam({ name: 'id', example: '67d233e71bb71f59d56de0b8', description: 'ID del profesor.' })
-      @ApiBody({ type: createProfesorDto })
+      @ApiBody({ type: updateProfesorDto })
       @ApiResponse({ status: 200, description: 'Profesor actualizado correctamente.' })
       @ApiResponse({ status: 404, description: 'No se encontró el profesor con el ID proporcionado.' })
       async update(@Param('id', ParseObjectIdPipe) id:string, @Body() updateProfesorDto: updateProfesorDto){


### PR DESCRIPTION
Los endpoints de la API no tenían documentación completa en Swagger. Cuando abríamos http://localhost:3000/api, los "request bodies" no mostraban ejemplos claros de los datos permitidos para enviar, haciendo un poco difícil probar la API.

Lo que hice fue:
**Commit 1:** Arreglar imports de UpdateDTOs (8 archivos)
  **Problema:** Los DTOs de actualización (update-xxx.dto) no mostraban sus campos en Swagger.

  **Solucion:** Cambiamos el import de PartialType:
  - Antes: import { PartialType } from '@nestjs/mapped-types'
  - **Ahora:** import { PartialType } from '@nestjs/swagger'

  Conn esto logramos que Swagger pueda leer los decoradores @ApiProperty y mostrar los campos correctamente.

**Commit 2:** Agregar ejemplos a los DTOs (8 archivos)
  **Problema:** Los campos de los DTOs no tenian ejemplos ni descripciones.

  **Solucion:** Agregamos @ApiProperty a cada campo con:
  - Ejemplo realista del dato
  - Descripcion de qué representa
  - Si es opcional o requerido

En este commit **También:** Eliminamos funciones trim externas y las pusimos inline usando @Transform(({ value }) => value?.trim()) para mantener consistencia con el resto de codigo.

**Commit 3:** Agregar decoradores Swagger a controladores (2 archivos)

  **Problema:** Los controladores de Idioma y Menu no tenían decoradores de Swager, por lo que no aparecían organizados en la documentacion.

**Commit 4:** Corregir tipos de DTO en PATCH (2 archivos)

  **Problema:** Los endpoints PATCH usaban CreateDto en vez de UpdateDto en el decorador @ApiBody, mostrando informacion incorrecta (todos los campos como requeridos cuando deberían ser opcionales **porque se trata de una actualizacion**).

  **Solucion:**
  - cursos.controller.ts línea 109: CreateCursoDto → UpdateCursoDto
  - profesor.controller.ts línea 94: createProfesorDto → updateProfesorDto
  
  Incluyo captura de referencia: 
  
<img width="2930" height="2586" alt="image" src="https://github.com/user-attachments/assets/5442b146-77a6-4f0a-bcee-692b4d0af3da" />

<img width="2916" height="1750" alt="image" src="https://github.com/user-attachments/assets/5a5f35d4-a4bf-463c-a23f-0747808a2e46" />

