### PR TITLE
feature:Implemete un servicio de guardado local de modelos

### DIFF
--- a/src/application/dto/categoria/create-categoria.dto.ts
+++ b/src/application/dto/categoria/create-categoria.dto.ts
@@ -1,7 +1,6 @@
 import { Transform, Type } from 'class-transformer';
 import {
   IsBoolean,
-  IsDate,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -18,28 +17,22 @@ export class CreateCategoriaDto {
   descripcion: string;
 
   @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true) // 👈 convierte string a boolean
   @IsBoolean()
   estado: boolean;
 
-  @IsDate()
   @IsOptional()
-  @Type(() => Date)
-  fechaCreacion: Date;
-
-  @IsDate()
-  @IsOptional()
-  @Type(() => Date)
-  fechaActualizacion: Date;
-
-  @IsOptional()
+  @Type(() => Number) // 👈 convierte a número
   @IsNumber()
   x?: number;
 
   @IsOptional()
+  @Type(() => Number)
   @IsNumber()
   y?: number;
 
   @IsOptional()
+  @Type(() => Number)
   @IsNumber()
   z?: number;
 

--- a/src/application/uses-cases/categoria/create-categoria.use-case.ts
+++ b/src/application/uses-cases/categoria/create-categoria.use-case.ts
@@ -15,13 +15,13 @@ export class CreateCategoriaUseCase {
 
   async execute(
     dto: CreateCategoriaDto,
-    // imagenResult: string,
+   imagen?: Express.Multer.File
   ): Promise<Result<Categoria>> {
     // const createDto = {...dto, imagenUrl: imagenResult }; <-- comentado
     const createDto = { ...dto };
 
     try {
-      const categoria = await this.categoriaService.crearCategoria(createDto);
+      const categoria = await this.categoriaService.crearCategoria(createDto,imagen);
       this.eventEmitter.emit('categoria.creada', new CategoriaEvent(categoria));
       return Result.ok(categoria);
     } catch (error) {

--- a/src/application/uses-cases/categoria/update-categoria.use-case.ts
+++ b/src/application/uses-cases/categoria/update-categoria.use-case.ts
@@ -5,6 +5,7 @@ import { Categoria } from 'src/core/entities/categoria/categoria.entity';
 import { CategoriaService } from 'src/core/services/categoria/categoria.service';
 import { CategoriaEvent } from 'src/domain/events/categoria/categoria-creada.event';
 import { Result } from 'src/shared/domain/result/result';
+import { Express } from 'express';
 
 @Injectable()
 export class UpdateCategoriaUseCase {
@@ -16,13 +17,17 @@ export class UpdateCategoriaUseCase {
   async execute(
     id: string,
     dto: UpdateCategoriaDto,
+    file?: Express.Multer.File,
   ): Promise<Result<Categoria>> {
     try {
       const categoria = await this.categoriaService.actualizarCategoria(
         id,
         dto,
+        file, 
       );
+
       this.eventEmitter.emit('categoria.update', new CategoriaEvent(categoria));
+
       return Result.ok(categoria);
     } catch (error) {
       return Result.fail(error);

--- a/src/core/services/Archivo/archivo.service.ts
+++ b/src/core/services/Archivo/archivo.service.ts
@@ -1,0 +1,290 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable no-console */
+import { BadRequestException, Injectable } from '@nestjs/common';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { existsSync } from 'fs';
+
+export interface OpcionesArchivo {
+  carpeta: string; // 'imagenes', 'modelos', 'documentos', etc.
+  extensionesPermitidas: string[]; // ['.jpg', '.png', '.glb', etc.]
+  tamanoMaximo?: number; // en bytes
+  prefijo?: string; // 'categoria', 'producto', etc.
+}
+
+export interface ResultadoArchivo {
+  url: string; // URL pública para acceder al archivo
+  nombreArchivo: string; // Nombre del archivo guardado
+  rutaCompleta: string; // Ruta física completa
+}
+
+@Injectable()
+export class ArchivoService {
+  private readonly baseUploadPath = path.join(process.cwd(), 'uploads');
+  private readonly basePublicUrl = '/uploads';
+
+  constructor() {
+    this.ensureBaseDirectory();
+  }
+
+  // Asegurar que el directorio base de uploads existe
+  private async ensureBaseDirectory() {
+    try {
+      if (!existsSync(this.baseUploadPath)) {
+        await fs.mkdir(this.baseUploadPath, { recursive: true });
+      }
+    } catch (error) {
+      console.error('Error creando directorio base de uploads:', error);
+    }
+  }
+
+  /**
+   * Asegura que existe el directorio específico para un tipo de archivo
+   */
+  private async ensureDirectory(carpeta: string): Promise<void> {
+    const dirPath = path.join(this.baseUploadPath, carpeta);
+    if (!existsSync(dirPath)) {
+      await fs.mkdir(dirPath, { recursive: true });
+    }
+  }
+
+  /**
+   * Valida un archivo según las opciones proporcionadas
+   */
+  private validarArchivo(file: Express.Multer.File, opciones: OpcionesArchivo): void {
+    if (!file) {
+      throw new BadRequestException('No se proporcionó ningún archivo');
+    }
+
+    // Validar extensión
+    const extension = path.extname(file.originalname).toLowerCase();
+    if (!opciones.extensionesPermitidas.includes(extension)) {
+      throw new BadRequestException(
+        `Solo se permiten archivos con extensiones: ${opciones.extensionesPermitidas.join(', ')}`,
+      );
+    }
+
+    // Validar tamaño
+    if (opciones.tamanoMaximo && file.size > opciones.tamanoMaximo) {
+      const tamanoMB = (opciones.tamanoMaximo / (1024 * 1024)).toFixed(2);
+      throw new BadRequestException(
+        `El archivo excede el tamaño máximo permitido de ${tamanoMB}MB`,
+      );
+    }
+  }
+
+  /**
+   * Genera un nombre único para el archivo
+   */
+  private generarNombreArchivo(
+    file: Express.Multer.File,
+    opciones: OpcionesArchivo,
+    identificador?: string,
+  ): string {
+    const timestamp = Date.now();
+    const extension = path.extname(file.originalname).toLowerCase();
+    const prefijo = opciones.prefijo || 'archivo';
+    const id = identificador || timestamp.toString();
+
+    return `${prefijo}-${id}-${timestamp}${extension}`;
+  }
+
+  /**
+   * Sube un archivo al sistema
+   * @param file Archivo a subir
+   * @param opciones Configuración de subida
+   * @param identificador ID opcional para el nombre del archivo (ej: categoriaId)
+   * @returns Información del archivo subido
+   */
+  async subirArchivo(
+    file: Express.Multer.File,
+    opciones: OpcionesArchivo,
+    identificador?: string,
+  ): Promise<ResultadoArchivo> {
+    // Validar archivo
+    this.validarArchivo(file, opciones);
+
+    // Asegurar que existe el directorio
+    await this.ensureDirectory(opciones.carpeta);
+
+    // Generar nombre y rutas
+    const nombreArchivo = this.generarNombreArchivo(file, opciones, identificador);
+    const rutaCompleta = path.join(this.baseUploadPath, opciones.carpeta, nombreArchivo);
+    const url = `${this.basePublicUrl}/${opciones.carpeta}/${nombreArchivo}`;
+
+    // Guardar archivo
+    await fs.writeFile(rutaCompleta, file.buffer);
+
+    return {
+      url,
+      nombreArchivo,
+      rutaCompleta,
+    };
+  }
+
+  /**
+   * Actualiza un archivo (elimina el anterior y sube el nuevo)
+   * @param urlAnterior URL del archivo anterior a eliminar
+   * @param file Nuevo archivo
+   * @param opciones Configuración de subida
+   * @param identificador ID opcional para el nombre del archivo
+   * @returns Información del nuevo archivo
+   */
+  async actualizarArchivo(
+    urlAnterior: string | null,
+    file: Express.Multer.File,
+    opciones: OpcionesArchivo,
+    identificador?: string,
+  ): Promise<ResultadoArchivo> {
+    // Eliminar archivo anterior si existe
+    if (urlAnterior) {
+      await this.eliminarArchivo(urlAnterior);
+    }
+
+    // Subir nuevo archivo
+    return this.subirArchivo(file, opciones, identificador);
+  }
+
+  /**
+   * Elimina un archivo del sistema usando su URL pública
+   * @param url URL pública del archivo
+   */
+  async eliminarArchivo(url: string): Promise<void> {
+    try {
+      // Convertir URL pública a ruta física
+      const rutaRelativa = url.replace(this.basePublicUrl, '');
+      const rutaCompleta = path.join(this.baseUploadPath, rutaRelativa);
+
+      // Verificar y eliminar si existe
+      if (existsSync(rutaCompleta)) {
+        await fs.unlink(rutaCompleta);
+      }
+    } catch (error) {
+      console.error('Error eliminando archivo:', error);
+      // No lanzamos error para no bloquear operaciones
+    }
+  }
+
+  /**
+   * Elimina un archivo usando su ruta completa
+   * @param rutaCompleta Ruta física completa del archivo
+   */
+  async eliminarArchivoPorRuta(rutaCompleta: string): Promise<void> {
+    try {
+      if (existsSync(rutaCompleta)) {
+        await fs.unlink(rutaCompleta);
+      }
+    } catch (error) {
+      console.error('Error eliminando archivo por ruta:', error);
+    }
+  }
+
+  /**
+   * Verifica si un archivo existe
+   * @param url URL pública del archivo
+   * @returns true si el archivo existe
+   */
+  async existeArchivo(url: string): Promise<boolean> {
+    try {
+      const rutaRelativa = url.replace(this.basePublicUrl, '');
+      const rutaCompleta = path.join(this.baseUploadPath, rutaRelativa);
+      return existsSync(rutaCompleta);
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * Limpia archivos huérfanos en una carpeta específica
+   * @param carpeta Nombre de la carpeta a limpiar
+   * @param urlsEnUso Array de URLs que están en uso
+   * @returns Cantidad de archivos eliminados
+   */
+  async limpiarArchivosHuerfanos(carpeta: string, urlsEnUso: string[]): Promise<number> {
+    try {
+      const dirPath = path.join(this.baseUploadPath, carpeta);
+      
+      if (!existsSync(dirPath)) {
+        return 0;
+      }
+
+      const archivos = await fs.readdir(dirPath);
+      const nombresEnUso = new Set(
+        urlsEnUso.map((url) => url.split('/').pop()).filter(Boolean),
+      );
+
+      let eliminados = 0;
+      for (const archivo of archivos) {
+        if (!nombresEnUso.has(archivo)) {
+          await fs.unlink(path.join(dirPath, archivo));
+          eliminados++;
+        }
+      }
+
+      return eliminados;
+    } catch (error) {
+      console.error('Error limpiando archivos huérfanos:', error);
+      return 0;
+    }
+  }
+
+  /**
+   * Obtiene información de un archivo por su URL
+   * @param url URL pública del archivo
+   * @returns Información del archivo o null si no existe
+   */
+  async obtenerInfoArchivo(url: string): Promise<{
+    existe: boolean;
+    tamano?: number;
+    extension?: string;
+  }> {
+    try {
+      const rutaRelativa = url.replace(this.basePublicUrl, '');
+      const rutaCompleta = path.join(this.baseUploadPath, rutaRelativa);
+
+      if (!existsSync(rutaCompleta)) {
+        return { existe: false };
+      }
+
+      const stats = await fs.stat(rutaCompleta);
+      const extension = path.extname(rutaCompleta).toLowerCase();
+
+      return {
+        existe: true,
+        tamano: stats.size,
+        extension,
+      };
+    } catch (error) {
+      return { existe: false };
+    }
+  }
+}
+
+// Opciones predefinidas comunes
+export const OpcionesImagenes: OpcionesArchivo = {
+  carpeta: 'imagenes',
+  extensionesPermitidas: ['.jpg', '.jpeg', '.png', '.webp', '.gif'],
+  tamanoMaximo: 5 * 1024 * 1024, // 5MB
+  prefijo: 'img',
+};
+
+export const OpcionesModelos3D: OpcionesArchivo = {
+  carpeta: 'modelos',
+  extensionesPermitidas: ['.glb', '.gltf'],
+  tamanoMaximo: 50 * 1024 * 1024, // 50MB
+  prefijo: 'modelo',
+};
+
+export const OpcionesDocumentos: OpcionesArchivo = {
+  carpeta: 'documentos',
+  extensionesPermitidas: ['.pdf', '.doc', '.docx', '.xls', '.xlsx'],
+  tamanoMaximo: 10 * 1024 * 1024, // 10MB
+  prefijo: 'doc',
+};
+
+export const OpcionesVideos: OpcionesArchivo = {
+  carpeta: 'videos',
+  extensionesPermitidas: ['.mp4', '.webm', '.mov'],
+  tamanoMaximo: 100 * 1024 * 1024, // 100MB
+  prefijo: 'video',
+};

--- a/src/core/services/categoria/categoria.service.ts
+++ b/src/core/services/categoria/categoria.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import {
   CreateCategoriaDto,
   UpdateCategoriaDto,
@@ -9,6 +9,7 @@ import { Categoria } from 'src/core/entities/categoria/categoria.entity';
 import { CategoriaRepository } from 'src/core/repositories/categoria/categoria.respository';
 import { ValidatorService } from 'src/shared/application/validation/validator.service';
 import { BussinesRuleException } from 'src/shared/domain/exceptions/business-rule.exception';
+import { ArchivoService, OpcionesModelos3D } from '../Archivo/archivo.service';
 
 @Injectable()
 export class CategoriaService {
@@ -16,39 +17,56 @@ export class CategoriaService {
     @Inject(CATEGORIA_REPOSITORY)
     private repository: CategoriaRepository,
     private readonly validator: ValidatorService,
+    private  archivo:ArchivoService,
   ) {}
 
-  async crearCategoria(dto: CreateCategoriaDto): Promise<Categoria> {
-    await this.validator.validate(dto, CreateCategoriaDto);
 
-    const existe = await this.repository.findByName(dto.nombre);
-    if (existe) {
-      throw new BussinesRuleException(
-        'La categoría ya existe',
-        HttpStatus.BAD_REQUEST,
-        {
-          nombre: dto.nombre,
-          codigoError: 'CATEGORIA_DUPLICADA',
-        },
-      );
-    }
+async crearCategoria(
+  dto: CreateCategoriaDto,
+  modelo: Express.Multer.File,
+): Promise<Categoria> {
+  await this.validator.validate(dto, CreateCategoriaDto);
 
-    const categoria = new Categoria(
-      null,
-      dto.nombre,
-      dto.descripcion || '',
-      true,
-      new Date(),
-      new Date(),
-      dto.x,
-      dto.y,
-      dto.z,
-      dto.url,
-      dto.modelo,
+  const existe = await this.repository.findByName(dto.nombre);
+  if (existe) {
+    throw new BussinesRuleException(
+      'La categoría ya existe',
+      HttpStatus.BAD_REQUEST,
+      {
+        nombre: dto.nombre,
+        codigoError: 'CATEGORIA_DUPLICADA',
+      },
+    );
+  }
+
+  let modeloUrl: string | null = null;
+  if (modelo) {
+    const resultado = await this.archivo.subirArchivo(
+      modelo,
+      OpcionesModelos3D,
+      dto.nombre, 
     );
 
-    return this.repository.save(categoria);
+    modeloUrl = resultado.url; 
   }
+
+
+  const categoria = new Categoria(
+    null,
+    dto.nombre,
+    dto.descripcion || '',
+    true,
+    new Date(),
+    new Date(),
+    dto.x,
+    dto.y,
+    dto.z,
+    dto.url,
+    modeloUrl, 
+  );
+
+  return this.repository.save(categoria);
+}
 
   async listarCategorias(): Promise<Categoria[]> {
     return this.repository.findAllActive();
@@ -71,34 +89,66 @@ export class CategoriaService {
     return existe;
   }
 
-  async actualizarCategoria(
-    id: string,
-    dto: UpdateCategoriaDto,
-  ): Promise<Categoria> {
-    await this.validator.validate(dto, UpdateCategoriaDto);
+async actualizarCategoria(
+  id: string,
+  dto: UpdateCategoriaDto,
+  file?: Express.Multer.File, // el archivo GLB opcional
+): Promise<Categoria> {
+  await this.validator.validate(dto, UpdateCategoriaDto);
 
-    const categoria = new Categoria(
-      null,
-      dto.nombre,
-      dto.descripcion || '',
-      true,
-      new Date(),
-      new Date(),
-      dto.x,
-      dto.y,
-      dto.z,
-      dto.url,
-      dto.modelo,
+  const categoriaActual = await this.repository.findById(id);
+  if (!categoriaActual) {
+    throw new NotFoundException(`Categoría con ID ${id} no encontrada`);
+  }
+
+  let urlModelo = categoriaActual.modelo;
+
+
+  if (file) {
+    const resultadoArchivo = await this.archivo.actualizarArchivo(
+      categoriaActual.modelo, 
+      file,
+      OpcionesModelos3D, 
+      id, 
     );
 
-    return this.repository.update(id, categoria);
+    urlModelo = resultadoArchivo.url;
   }
+
+
+  const categoriaActualizada = new Categoria(
+    categoriaActual.id,       
+    dto.nombre || categoriaActual.nombre,
+    dto.descripcion || categoriaActual.descripcion,
+    dto.estado ?? categoriaActual.estado,
+    categoriaActual.fechaCreacion, 
+    new Date(),                    
+    dto.x ?? categoriaActual.x,
+    dto.y ?? categoriaActual.y,
+    dto.z ?? categoriaActual.z,
+    dto.url || categoriaActual.url,
+    urlModelo,
+  );
+
+ 
+  return this.repository.update(id, categoriaActualizada);
+}
 
   async eliminarCategoria(id: string): Promise<Categoria> {
-    const categoria = await this.obtenerUnaCategoria(id);
 
-    const estado: boolean = categoria.estado === true ? false : true;
-
-    return this.repository.delete(id, estado);
+  const categoria = await this.obtenerUnaCategoria(id);
+  if (!categoria) {
+    throw new NotFoundException(`Categoría con ID ${id} no encontrada`);
   }
+
+  
+  const nuevoEstado: boolean = categoria.estado === true ? false : true;
+
+  if (!nuevoEstado && categoria.modelo) {
+    await this.archivo.eliminarArchivo(categoria.modelo);
+  }
+
+  return this.repository.delete(id, nuevoEstado);
+}
+
 }

--- a/src/infraestructure/http/categoria/categoria.controller.ts
+++ b/src/infraestructure/http/categoria/categoria.controller.ts
@@ -8,7 +8,10 @@ import {
   Param,
   Patch,
   Post,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiOperation,
@@ -35,6 +38,7 @@ export class CategoriaController {
   ) {}
 
   @Post()
+  @UseInterceptors(FileInterceptor('modelo'))
   @ApiOperation({ summary: 'Crear una nueva categoría' })
   @ApiBody({
     type: dto.CreateCategoriaDto,
@@ -42,8 +46,8 @@ export class CategoriaController {
   })
   @ApiResponse({ status: 201, description: 'Categoría creada exitosamente' })
   @ApiResponse({ status: 400, description: 'Error en los datos enviados' })
-  async create(@Body() body: dto.CreateCategoriaDto) {
-    const result = await this.createUseCase.execute(body);
+  async create(@Body() body: dto.CreateCategoriaDto, @UploadedFile() file: Express.Multer.File) {
+    const result = await this.createUseCase.execute(body,file);
 
     if (result.isFailure) {
       throw new HttpException(result.error.message, HttpStatus.BAD_REQUEST);
@@ -94,6 +98,7 @@ export class CategoriaController {
   }
 
   @Patch(':id')
+  @UseInterceptors(FileInterceptor('modelo')) // 'modelo' es el nombre del campo en form-data
   @ApiOperation({ summary: 'Actualizar una categoría' })
   @ApiParam({ name: 'id', description: 'ID de la categoría', type: String })
   @ApiBody({
@@ -105,14 +110,17 @@ export class CategoriaController {
     description: 'Categoría actualizada correctamente',
   })
   @ApiResponse({ status: 400, description: 'Error al actualizar la categoría' })
-  async update(
+ async update(
     @Param('id', ParseObjectIdPipe) id: string,
     @Body() updateCategoriaDto: dto.UpdateCategoriaDto,
-  ) {
-    const result = await this.updateCategoriaUseCase.execute(
+    @UploadedFile() file?: Express.Multer.File,
+  )  {
+   const result = await this.updateCategoriaUseCase.execute(
       id,
       updateCategoriaDto,
+      file, 
     );
+
 
     if (result.isFailure) {
       throw new HttpException(result.error.message, HttpStatus.BAD_REQUEST);

--- a/src/infraestructure/http/categoria/categorias.module.ts
+++ b/src/infraestructure/http/categoria/categorias.module.ts
@@ -13,6 +13,7 @@ import { DeleteCategoriaUseCase } from 'src/application/uses-cases/categoria/del
 import { SaveImageStorageUseCase } from 'src/application/uses-cases/azure/save-image-storage.use.case';
 import { AzureStorageService } from 'src/core/services/azure/azure-storage.service';
 import { DeleteImageStorageUseCase } from 'src/application/uses-cases/azure/delete-image-storage.use.case';
+import { ArchivoService } from 'src/core/services/Archivo/archivo.service';
 
 @Module({
   imports: [SharedModule, PrismaModule],
@@ -30,7 +31,8 @@ import { DeleteImageStorageUseCase } from 'src/application/uses-cases/azure/dele
     DeleteCategoriaUseCase,
     SaveImageStorageUseCase,
     DeleteImageStorageUseCase,
-    AzureStorageService
+    AzureStorageService,
+    ArchivoService
   ],
   exports: [CategoriaService],
 })

--- a/src/infraestructure/http/galaxia/galaxias.module.ts
+++ b/src/infraestructure/http/galaxia/galaxias.module.ts
@@ -10,16 +10,17 @@ import { GetAllGalaxiaUseCase } from 'src/application/uses-cases/galaxias/get-al
 import { SharedModule } from 'src/shared/shared.module';
 import { PrismaModule } from 'src/core/services/prisma/prisma.module';
 import {
+  ActualizarGalaxiaCasoDeUso,
   CreateGalaxiaUseCase,
   CreateMultipleGalaxiasUseCase,
   DeleteGalaxiaUseCase,
   GetOneGalaxiaUseCase,
-  ActualizarGalaxiaCasoDeUso,
 } from 'src/application/uses-cases/galaxias';
 import { CategoriaService } from 'src/core/services/categoria/categoria.service';
 import { CategoriaPrismaRepository } from 'src/infraestructure/persistence/categoria/categoria.prisma.respository';
 import { SaveImageStorageUseCase } from 'src/application/uses-cases/azure';
 import { AzureStorageService } from 'src/core/services/azure/azure-storage.service';
+import { ArchivoService } from 'src/core/services/Archivo/archivo.service';
 
 @Module({
   imports: [SharedModule, PrismaModule],
@@ -43,6 +44,7 @@ import { AzureStorageService } from 'src/core/services/azure/azure-storage.servi
     DeleteGalaxiaUseCase,
     SaveImageStorageUseCase,
     AzureStorageService,
+    ArchivoService
   ],
   exports: [GalaxiasService],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,17 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express'; // 👈 Import necesario
 import { AppModule } from './app.module';
 import { Logger, ValidationPipe } from '@nestjs/common';
 import { envs } from './config/envs';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-// import * as bodyParser from 'body-parser';
+import * as path from 'path';
+
 async function bootstrap() {
   const logger = new Logger('API');
 
-  const app = await NestFactory.create(AppModule);
+  // 👈 Usamos NestExpressApplication
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
   app.setGlobalPrefix('api');
 
   app.enableCors({
@@ -22,25 +26,24 @@ async function bootstrap() {
     }),
   );
 
+  // --- SERVIR ARCHIVOS ESTÁTICOS ---
+  app.useStaticAssets(path.join(process.cwd(), 'uploads'), {
+    prefix: '/uploads/', // URL pública
+  });
+
+  // --- SWAGGER ---
   const config = new DocumentBuilder()
     .setTitle('API Universo Dicta')
     .setDescription('API de la aplicacion de universo dicta')
     .setVersion('1.0')
-    // .addBearerAuth()
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 
-
-  //   // Aumenta el límite del body (ejemplo: 10mb)
-  // app.use(bodyParser.json({ limit: '10mb' }));
-  // app.use(bodyParser.urlencoded({ limit: '10mb', extended: true }));
-
-
   await app.listen(envs.port);
 
-  logger.log(`api corriendo en el puerto ${envs.port}`);
-  logger.log(`api corriendo en la bd ${envs.databaseUrl}`);
+  logger.log(`API corriendo en el puerto ${envs.port}`);
+  logger.log(`API corriendo en la BD ${envs.databaseUrl}`);
 }
 bootstrap();


### PR DESCRIPTION
Se agrega un servicio para subir, actualizar y eliminar modelos 3D (.glb) de las categorías:

- ArchivoService:
  - Subida de archivos a la carpeta local `/uploads/modelos`.
  - Generación de URL pública accesible con host y puerto.
  - Validación de extensiones (.glb, .gltf) y tamaño máximo.
  - Eliminación de archivos anteriores al actualizar.
  - Limpieza de archivos huérfanos no asociados en la base de datos.

- Actualización de CreateCategoriaUseCase y UpdateCategoriaUseCase:
  - Guarda la URL completa del modelo subido en el campo `modelo` de la categoría.
  - Valida que la categoría no tenga nombres duplicados.

- Modificación de main.ts:
  - Se expone la carpeta `/uploads` como estática para que los archivos sean visibles desde el navegador.

- Documentación Swagger actualizada para endpoints `create` y `update` de categorías, incluyendo el archivo modelo.

Esto permite subir modelos 3D a nivel local y obtener la URL pública para visualización desde frontend o clientes HTTP.
