### PR TITLE
feat: Limitar categorías a 3 registros 

### DIFF
--- a/src/core/repositories/categoria/categoria.respository.ts
+++ b/src/core/repositories/categoria/categoria.respository.ts
@@ -5,6 +5,7 @@ export interface CategoriaRepository {
   findById(id: string): Promise<Categoria | null>;
   findByName(nombre: string): Promise<Categoria | null>;
   findAllActive(): Promise<Categoria[]>;
+  countActive(): Promise<number>;
   save(categoria: Categoria): Promise<Categoria>;
   update(id: string, categoria: Partial<Categoria>): Promise<Categoria>;
   delete(id: string, estado: boolean): Promise<Categoria>;

--- a/src/core/services/categoria/categoria.service.ts
+++ b/src/core/services/categoria/categoria.service.ts
@@ -33,6 +33,18 @@ export class CategoriaService {
       );
     }
 
+    const totalCategorias = await this.repository.countActive();
+    if (totalCategorias >= 3) {
+      throw new BussinesRuleException(
+        'No se pueden crear más de 3 categorías',
+        HttpStatus.BAD_REQUEST,
+        {
+          totalActual: totalCategorias, // total actual de categorías
+          codigoError: 'LIMITE_CATEGORIAS_ALCANZADO',
+        },
+      );
+    }
+    
     const categoria = new Categoria(
       null,
       dto.nombre,

--- a/src/infraestructure/http/categoria/categoria.controller.ts
+++ b/src/infraestructure/http/categoria/categoria.controller.ts
@@ -41,7 +41,7 @@ export class CategoriaController {
     description: 'Datos para crear la categoría',
   })
   @ApiResponse({ status: 201, description: 'Categoría creada exitosamente' })
-  @ApiResponse({ status: 400, description: 'Error en los datos enviados' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos, categoría duplicada o límite de 3 categorías alcanzado' })
   async create(@Body() body: dto.CreateCategoriaDto) {
     const result = await this.createUseCase.execute(body);
 

--- a/src/infraestructure/persistence/categoria/categoria.prisma.respository.ts
+++ b/src/infraestructure/persistence/categoria/categoria.prisma.respository.ts
@@ -47,6 +47,13 @@ export class CategoriaPrismaRepository implements CategoriaRepository {
     return Categoria.fromPrismaList(categorias);
   }
 
+  async countActive(): Promise<number> {
+    const count = await this.prisma.categoria.count({
+      where: { estado: true },
+    });
+    return count;
+  }
+
   async update(id: string, categoria: Partial<Categoria>): Promise<Categoria> {
     const data = await this.prisma.categoria.update({
       where: { id },


### PR DESCRIPTION
Se implementa validación para limitar las categorías a 3 registros
### Implementación

  Se siguió el patrón arquitectónico del proyecto (validaciones en Services):

  1. Agregado método `countActive()` en repositorio
  2. Implementación Prisma del conteo
  3. Validación en servicio que lanza error si `totalCategorias >= 3`
  4. Actualización de documentación Swagger

  ### Error retornado

  ```json
  {
    "statusCode": 400,
    "message": "No se pueden crear más de 3 categorías",
    "error": {
      "totalActual": 3,
      "codigoError": "LIMITE_CATEGORIAS_ALCANZADO"
    }
  }
  ```
### Imagen
  
<img width="2882" height="3434" alt="image" src="https://github.com/user-attachments/assets/cde41e6a-36e1-4046-be5e-792a3dc8d6e2" />
