### PR TITLE
Refactor: se quito el unique a slug y a titulo y se arreglo el metodo…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -219,12 +219,12 @@ type Color {
 
 model LandingPage {
   id                  String             @id @default(auto()) @map("_id") @db.ObjectId
-  titulo              String             @unique
+  titulo              String             
   descripcion         String
   imagenPrincipal     String
   contenido           String[]
   estado              Boolean            @default(true)
-  slug                String             @unique
+  slug                String             
   metaKeywords        String
   landingUrl          String
   fechaCreacion       DateTime           @default(now())

--- a/src/core/repositories/landing-page/landing-page.repository.ts
+++ b/src/core/repositories/landing-page/landing-page.repository.ts
@@ -7,9 +7,9 @@ import { LandingPage } from 'src/core/entities/landing-page/landing-page.entity'
 export interface LandingPageRepository {
   findById(id: string): Promise<LandingPage | null>;
   findByTitulo(titulo: string): Promise<LandingPage | null>;
-  findAllActive(): Promise<LandingPage[]>;
+  findAll(): Promise<LandingPage[]>;
   save(landingPage: LandingPage): Promise<LandingPage>;
   update(id: string, landingPage: Partial<LandingPage>): Promise<LandingPage>;
   delete(id: string, estado: boolean): Promise<LandingPage>;
+  findBySlug(slug: string): Promise<LandingPage | null>;
 }
-  

--- a/src/infraestructure/http/landing-page/landing-page.controller.ts
+++ b/src/infraestructure/http/landing-page/landing-page.controller.ts
@@ -40,7 +40,6 @@ export class LandingPageController {
     }
     
     return {
-      data: result,
       message: 'Landing page creada',
     };
   }
@@ -55,7 +54,7 @@ export class LandingPageController {
     }
 
     return {
-      data: result,
+      data: result.getValue(),
       message: 'Landing pages obtenidas',
     };
   }
@@ -70,7 +69,7 @@ export class LandingPageController {
   }
 
     return {
-      data: result,
+      data: result.getValue(),
       message: 'Landing page obtenida',
     };
   }
@@ -88,7 +87,6 @@ export class LandingPageController {
     }
 
     return {
-      data: result,
       message: 'Landing page actualizada',
     };
   }
@@ -103,7 +101,6 @@ export class LandingPageController {
     }
 
     return {
-      data: result,
       message: 'Landing page eliminada',
     };
   }

--- a/src/infraestructure/persistence/landing-page/landing-page.prisma.repository.ts
+++ b/src/infraestructure/persistence/landing-page/landing-page.prisma.repository.ts
@@ -21,7 +21,7 @@ export class LandingPagePrismaRepository implements LandingPageRepository {
   }
 
   async findById(id: string): Promise<LandingPage | null> {
-    const data = await this.prisma.landingPage.findUnique({
+    const data = await this.prisma.landingPage.findFirst({
       where: { id },
       include: {
         itemImagenesLanding: true,
@@ -33,7 +33,7 @@ export class LandingPagePrismaRepository implements LandingPageRepository {
   }
 
   async findBySlug(slug: string): Promise<LandingPage | null> {
-    const data = await this.prisma.landingPage.findUnique({
+    const data = await this.prisma.landingPage.findFirst({
       where: { slug },
     });
 
@@ -73,11 +73,8 @@ export class LandingPagePrismaRepository implements LandingPageRepository {
     return this.landingPageFactory.crearDesdePrismaConRelaciones(data);
   }
 
-  async findAllActive(): Promise<LandingPage[]> {
+  async findAll(): Promise<LandingPage[]> {
     const landingPages = await this.prisma.landingPage.findMany({
-      where: {
-        estado: true,
-      },
       include: {
         itemImagenesLanding: true,
         itemColores: true,


### PR DESCRIPTION
Actualización de la entidad Landing Page

Descripción
Se realizaron ajustes en la entidad Landing Page para modificar las restricciones de unicidad y mejorar el filtrado de registros al momento de la consulta.

Issue relacionada

Issue https://github.com/Dicta-Enterprise/back-nest-universo-dicta/issues/35

Cambios realizados

Modificación de atributos

Se eliminó la restricción unique de los campos slug y title en la entidad Landing Page.

Ajuste en la obtención de registros

Se modificó la consulta para que al obtener las landing pages se incluyan los registros con estado true y false.

¿Qué se hizo?

Actualización del modelo para permitir valores repetidos en slug y title.

Ajuste en la lógica de consulta para no filtrar únicamente por estado activo.

¿Por qué se hizo?

Asegurar que las consultas puedan retornar tanto registros activos como inactivos según lo requerido por el sistema.

<img width="1920" height="1021" alt="{A75D73A7-79F6-43E6-AA5C-A98C94AA11FA}" src="https://github.com/user-attachments/assets/f3d7a7c9-0212-44bf-9387-4af7b07c0139" />

<img width="1920" height="1080" alt="{969391D5-9C1C-4EBC-BF9A-7BC4FF1AEEE9}" src="https://github.com/user-attachments/assets/0cc14df2-f761-456c-8898-48baac5082cf" />

<img width="1920" height="1080" alt="{7C907B99-07F2-42B1-A7A9-2361083BDB9B}" src="https://github.com/user-attachments/assets/f55ab9d2-e11a-481c-82f6-1e813effc2cb" />


