### PR TITLE
Refactor: Se elimino la restriccion de unique en nombre

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,8 +99,8 @@ model Profesor {
 
 model Planeta {
   id                 String         @id @default(auto()) @map("_id") @db.ObjectId
-  categoria             String
-  nombre             String         @unique
+  categoria          String
+  nombre             String         
   estado             EstadoGenerico @default(ACTIVO)
   textura            String
   url                String
@@ -112,8 +112,6 @@ model Planeta {
   galaxia            Galaxia        @relation(fields: [galaxiaId], references: [id])
   galaxiaId          String         @db.ObjectId
   cursos             Curso[]
-
-  @@unique([nombre, galaxiaId])
 }
 
 type InfoPlaneta {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,7 +23,7 @@ import { LandingPageModule } from './infraestructure/http/landing-page/landing-p
     IdiomaModule,
     ProfesorModule,
     AzureModule,
-    ParametersModule
+    ParametersModule,
     MenuModule,
     LandingPageModule
   ],

--- a/src/core/services/planeta/planetas.service.ts
+++ b/src/core/services/planeta/planetas.service.ts
@@ -20,20 +20,11 @@ export class PlanetasService {
   ) {}
 
   async crearPlaneta(dtoPlaneta: CreatePlanetaDto): Promise<Planeta> {
+
     await this.validator.validate(dtoPlaneta, CreatePlanetaDto);
 
-    const existe = await this.repository.findByName(dtoPlaneta.nombre);
-    if (existe) {
-      throw new BussinesRuleException(
-        `El planeta con el nombre ${dtoPlaneta.nombre} ya existe en esta galaxia `,
-        HttpStatus.BAD_REQUEST,
-        {
-          nombre: dtoPlaneta.nombre,
-          codigoError: 'PLANETA_DUPLICADO',
-        },
-      );
-    }
     const galaxia = await this.galaxiasService.obtenerGalaxia(dtoPlaneta.galaxiaId);
+
     if (!galaxia) {
       throw new BussinesRuleException(
         `La galaxia con ID ${dtoPlaneta.galaxiaId} no existe`,
@@ -44,7 +35,6 @@ export class PlanetasService {
         },
       );
     }
-
 
     const planeta = new Planeta(
       null,
@@ -108,20 +98,34 @@ export class PlanetasService {
     id: string,
     dtoPlaneta: UpdatePlanetaDto,
   ): Promise<Planeta> {
+
     await this.validator.validate(dtoPlaneta, UpdatePlanetaDto);
-    const existe = await this.repository.findByName(dtoPlaneta.nombre);
-    if (existe) {
+
+    const planetaExistente = await this.repository.findById(id);
+
+    if (!planetaExistente) {
       throw new BussinesRuleException(
-        `No puedes editar el planeta. Ya existe otro con el nombre ${dtoPlaneta.nombre} en esta galaxia`,
-        HttpStatus.BAD_REQUEST,
+        'El planeta no existe.',
+        HttpStatus.NOT_FOUND,
         {
-          nombre: dtoPlaneta.nombre,
-          codigoError: 'PLANETA_DUPLICADO',
+          id: id,
+          codigoError: 'PLANETA_NO_ENCONTRADO',
         },
       );
     }
 
-        const galaxia = await this.galaxiasService.obtenerGalaxia(dtoPlaneta.galaxiaId);
+    if (!dtoPlaneta.galaxiaId) {
+      throw new BussinesRuleException(
+        'Debe enviar galaxiaId para actualizar el planeta',
+        HttpStatus.BAD_REQUEST,
+        {
+          codigoError: 'GALAXIA_ID_REQUERIDO',
+        },
+      );
+    }
+
+    const galaxia = await this.galaxiasService.obtenerGalaxia(dtoPlaneta.galaxiaId);
+
     if (!galaxia) {
       throw new BussinesRuleException(
         `La galaxia con ID ${dtoPlaneta.galaxiaId} no existe`,
@@ -134,19 +138,19 @@ export class PlanetasService {
     }
 
     const planeta = new Planeta(
-      null,
-      dtoPlaneta.nombre,
-      dtoPlaneta.categoria,
-      dtoPlaneta.galaxia,
-      dtoPlaneta.textura,
-      dtoPlaneta.url,
-      dtoPlaneta.imagenResumen,
-      dtoPlaneta.resumenCurso,
-      dtoPlaneta.estado ?? EstadoGenerico.ACTIVO,
+      id,
+      dtoPlaneta.nombre ?? planetaExistente.nombre,
+      dtoPlaneta.categoria ?? planetaExistente.categoria,
+      galaxia.nombre,
+      dtoPlaneta.textura ?? planetaExistente.textura,
+      dtoPlaneta.url ?? planetaExistente.url,
+      dtoPlaneta.imagenResumen ?? planetaExistente.imagenResumen,
+      dtoPlaneta.resumenCurso ?? planetaExistente.resumenCurso,
+      dtoPlaneta.estado ?? planetaExistente.estado,
       dtoPlaneta.galaxiaId,
-      dtoPlaneta.info,
-      dtoPlaneta.peligros ?? [],
-      dtoPlaneta.beneficios ?? [],
+      dtoPlaneta.info ?? planetaExistente.info,
+      dtoPlaneta.peligros ?? planetaExistente.peligros,
+      dtoPlaneta.beneficios ?? planetaExistente.beneficios,
     );
 
     return this.repository.update(id, planeta);

--- a/src/infraestructure/persistence/planeta/planeta.prisma.respository.ts
+++ b/src/infraestructure/persistence/planeta/planeta.prisma.respository.ts
@@ -18,7 +18,8 @@ export class PlanetaPrismaRepository implements PlanetaRepository {
   ) {}
 
   async findById(id: string): Promise<Planeta | null> {
-    const data = await this.prisma.planeta.findUnique({
+    if (!id) return null;
+    const data = await this.prisma.planeta.findFirst({
       where: { id },
       include: galaxiaInclude,
     });
@@ -26,7 +27,7 @@ export class PlanetaPrismaRepository implements PlanetaRepository {
   }
 
   async findByName(nombre: string): Promise<Planeta | null> {
-    const data = await this.prisma.planeta.findUnique({
+    const data = await this.prisma.planeta.findFirst({
       where: { nombre },
       include: galaxiaInclude,
     });


### PR DESCRIPTION
Descripción

Este PR elimina la restricción unique del campo nombre en el modelo Planeta. El objetivo es permitir que existan múltiples planetas con el mismo nombre sin generar errores en la base de datos.

Issue relacionada

Issue #22

Cambios principales

Se removió la restricción @unique del campo nombre en el modelo Planeta.

Se actualizó el esquema para permitir nombres duplicados en planetas.

Consideraciones

Cada planeta sigue siendo identificado de forma única por su id, por lo que permitir nombres repetidos no afecta la integridad de los datos.


<img width="1920" height="1080" alt="{916550E4-6EE8-48DE-97EE-47BEDF3EEFE8}" src="https://github.com/user-attachments/assets/364436bb-292d-4a43-b328-015d1fda76ab" />
<img width="1920" height="1080" alt="{A894BB98-D23F-42D5-B62E-3CF9C1F8C893}" src="https://github.com/user-attachments/assets/9195bb67-66df-4525-8650-7e477d46c114" />
<img width="1920" height="1080" alt="{3FD8FA37-CA2E-46B6-BCCC-61E744AB0281}" src="https://github.com/user-attachments/assets/b985258a-8b1a-4255-a3ef-573abc4b33c0" />
<img width="1920" height="1080" alt="{DA47F254-8E7F-4C4D-8F5B-4893CB18F52F}" src="https://github.com/user-attachments/assets/7ed00ac9-7714-49cd-80c9-59f34295498d" />
<img width="1920" height="1080" alt="{97662827-C00E-4F9E-A384-63F4CBFD8B62}" src="https://github.com/user-attachments/assets/a1085083-055e-4aa5-a36b-691190199a9c" />
<img width="1920" height="1080" alt="{1D7EA2AB-4052-4A63-85F0-734A22B4C72E}" src="https://github.com/user-attachments/assets/ff141c40-7a6f-41ec-b54d-bc2077527806" />
<img width="1920" height="1080" alt="{4562FD50-3D34-4D69-BFFB-E4974067C425}" src="https://github.com/user-attachments/assets/a5122bd2-1e34-4b0b-aa62-eea2f5eed5c7" />
