### PR TITLE
 Refactor: Galaxias con el mismo nombre error (issue #45)

### DIFF
--- a/src/application/dto/galaxia/create-multiple-galaxia.dto.ts
+++ b/src/application/dto/galaxia/create-multiple-galaxia.dto.ts
@@ -6,6 +6,7 @@ import {
   IsBoolean,
   IsMongoId,
   IsNotEmpty,
+  IsOptional,
   IsString,
   IsUrl,
   ValidateNested,
@@ -17,22 +18,20 @@ export class GalaxiaDataDto {
     example: 'salud-mental',
     description: 'Tema de la galaxia para motor 3D',
   })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  tema: string;
+  tema?: string;
 
-  @ApiPropertyOptional({
-    example: 'Salud Social 1',
-    description:
-      'Nombre individual de la galaxia (opcional, hereda del grupo si no se especifica)',
+  @ApiProperty({
+    example: 'Salud Social Infantil',
+    description: 'Nombre de la galaxia',
   })
   @IsString()
   @IsNotEmpty()
   nombre: string;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     example: 'Descripción específica de esta galaxia',
-    description: 'Descripción individual (opcional, hereda del grupo)',
   })
   @IsString()
   @IsNotEmpty()
@@ -46,41 +45,55 @@ export class GalaxiaDataDto {
   @IsNotEmpty()
   categoriaId: string;
 
-  @ApiPropertyOptional({ example: null, nullable: true })
+  @ApiPropertyOptional({
+    example: null,
+    nullable: true,
+  })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  imagen: string | null;
+  imagen?: string | null;
 
-  @ApiProperty({ example: 'https://example.com/salud-social' })
+  @ApiProperty({
+    example: 'https://example.com/salud-social',
+  })
   @IsUrl()
   @IsNotEmpty()
   url: string;
 
-  @ApiProperty({ example: 'salud-social-textura.png' })
+  @ApiProperty({
+    example: 'salud-social-textura.png',
+  })
   @IsString()
   @IsNotEmpty()
   textura: string;
 
-  @ApiProperty({ example: '#FE797B' })
+  @ApiProperty({
+    example: '#FE797B',
+  })
   @IsString()
   @IsNotEmpty()
   color: string;
 
-  @ApiProperty({ example: true, default: true })
+  @ApiPropertyOptional({
+    example: true,
+    default: true,
+  })
+  @IsOptional()
   @IsBoolean()
-  @IsNotEmpty()
   estado?: boolean;
 
-  @ApiProperty({ example: { x: -13, y: 1, z: 3 } })
+  @ApiProperty({
+    example: { x: -13, y: 1, z: 3 },
+  })
   @ValidateNested()
   @Type(() => Vector3Dto)
-  @IsNotEmpty()
   posicion: Vector3Dto;
 
-  @ApiProperty({ example: { x: 1.847995880179171, y: 0, z: 5 } })
+  @ApiProperty({
+    example: { x: 1.84, y: 0, z: 5 },
+  })
   @ValidateNested()
   @Type(() => Vector3Dto)
-  @IsNotEmpty()
   rotacion: Vector3Dto;
 }
 
@@ -88,22 +101,6 @@ export class CreateMultipleGalaxiasDto {
   @ApiProperty({
     type: [GalaxiaDataDto],
     description: 'Array de galaxias a crear',
-    example: [
-      {
-        categoriaId: '689e130abb9772d4bb7b983f',
-        imagen: null,
-        url: 'https://example.com/salud-social',
-        textura: 'salud-social-textura.png',
-        color: '#FE797B',
-        posicion: { x: -13, y: 1, z: 3 },
-        rotacion: { x: 1.847995880179171, y: 0, z: 5 },
-        nombre: 'Salud Social Infantil',
-        descripcion: 'Versión para niños',
-        tema: 'salud-social-infantil',
-        estado: true,
-        categoria: 'Jovenes',
-      },
-    ],
   })
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/core/services/galaxia/galaxias.service.ts
+++ b/src/core/services/galaxia/galaxias.service.ts
@@ -31,23 +31,6 @@ export class GalaxiasService {
   async crearGalaxia(createGalaxiaDto: CreateGalaxiaDto): Promise<Galaxia> {
     await this.validator.validate(createGalaxiaDto, CreateGalaxiaDto);
 
-    const existe = await this.repository.findByNombreYCategoria(
-      createGalaxiaDto.nombre,
-      createGalaxiaDto.categoriaId,
-    );
-
-    if (existe) {
-      throw new BussinesRuleException(
-        'Ya existe una galaxia con ese nombre en la misma categoría',
-        HttpStatus.BAD_REQUEST,
-        {
-          nombre: createGalaxiaDto.nombre,
-          categoriaId: createGalaxiaDto.categoriaId,
-          codigoError: 'GALAXIA_DUPLICADA_EN_CATEGORIA',
-        },
-      );
-    }
-
     const categoria = await this.categoriaService.obtenerUnaCategoria(
       createGalaxiaDto.categoriaId,
     );


### PR DESCRIPTION
Descripción
Se implementó la funcionalidad para crear múltiples galaxias en una sola solicitud mediante el endpoint /galaxias/multiple. Para ello se definió el DTO CreateMultipleGalaxiasDto, que permite recibir un arreglo de galaxias con sus propiedades necesarias (nombre, tema, descripción, categoría, posición, rotación, etc.). Ademas se quito la validacion de nombres unicos

Además, se corrigieron las validaciones del DTO para permitir campos opcionales como imagen, evitando errores cuando se envía null o no se incluye el campo.
Issue relacionada
Issue https://github.com/Dicta-Enterprise/back-nest-universo-dicta/issues/45

Cambios principales
Se implementó el DTO CreateMultipleGalaxiasDto para manejar la creación de múltiples galaxias.

Se agregó la clase GalaxiaDataDto para validar cada objeto del arreglo de galaxias.

Se ajustaron las validaciones de imagen para permitir valores opcionales (null o no enviados).

Se eliminó el campo categoria del DTO múltiple, ya que solo se requiere categoriaId.

Porque se hizo

Esta funcionalidad permite crear varias galaxias en una sola petición, reduciendo la cantidad de llamadas al API

<img width="1920" height="1080" alt="{A2884FE4-95B2-4A1A-AF74-3B7788891112}" src="https://github.com/user-attachments/assets/194bb126-8614-4511-bd4b-ba09fda280e2" />

<img width="1920" height="1080" alt="{D5653919-6D14-4AB4-83C4-9BA4AB518665}" src="https://github.com/user-attachments/assets/3b324498-870b-4d47-893e-5dfa082288ad" />

