### PR TITLE
Refactor: Error en el DTO de crear cursos (issue #44)

### DIFF
--- a/src/application/dto/curso/create-curso.dto.ts
+++ b/src/application/dto/curso/create-curso.dto.ts
@@ -1,7 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
-import {  IsArray,IsBoolean, IsDate, IsMongoId, IsNotEmpty, IsNumber, IsOptional, IsString, IsUrl, Matches, Max, MaxLength, Min, MinLength, ValidateNested, } from 'class-validator';
-
+import {
+  IsArray,
+  IsBoolean,
+  IsDate,
+  IsMongoId,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Matches,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
 
 class BeneficioDto {
   @IsString()
@@ -12,125 +27,139 @@ class BeneficioDto {
   @IsNotEmpty()
   descripcion: string;
 }
+
 export class CreateCursoDto {
 
-  @ApiProperty({ 
-          example: 'Matemática básica.',
-          description: 'Nombre del curso.'
-      })
-  @MinLength(2, {message: 'El nombre debe tener mas de 1 carácter.'})
-  @MaxLength(100, {message: 'El nombre debe tener menos de 100 caracteres.'})
-  @IsString({message: 'El nombre debe ser un dato de tipo String.'})
-  @IsNotEmpty({message: 'El nombre no debe estar vacío.'})
-  @Matches(/^[A-Za-zÁÉÍÓÚáéíóúÑñ0-9 ]+$/, {
-      message: 'El nombre solo puede contener letras, números y espacios',
+  @ApiProperty({
+    example: 'Matemática básica.',
+    description: 'Nombre del curso.'
+  })
+  @MinLength(2, { message: 'El nombre debe tener mas de 1 carácter.' })
+  @MaxLength(100, { message: 'El nombre debe tener menos de 100 caracteres.' })
+  @IsString({ message: 'El nombre debe ser un dato de tipo String.' })
+  @IsNotEmpty({ message: 'El nombre no debe estar vacío.' })
+  @Matches(/^[A-Za-zÁÉÍÓÚáéíóúÑñ0-9 .,:;()\-]+$/, {
+    message: 'El nombre solo puede contener letras, números y signos básicos',
   })
   nombre: string;
 
-  @ApiProperty({ 
-        example: 'Curso para aprender a realizar operaciones con los operadores matemáticos.',
-        description: 'Descripción del curso.'
-    })
-  @MinLength(2, {message: 'La descripción debe tener mas de 2 caracteres.'})
-  @MaxLength(1000, {message: 'La descripción debe tener menos de 1000 caracteres.'})
-  @IsString({message: 'La descripción debe ser un dato de tipo String.'})
-  @IsNotEmpty({message: 'La descripción no debe estar vacía.'})
-  @Matches(/^[A-Za-zÁÉÍÓÚáéíóúÑñ0-9 ]+$/, {
-    message: 'La descripción solo puede contener letras, números y espacios',
-    })
+  @ApiProperty({
+    example: 'Curso para aprender a realizar operaciones con los operadores matemáticos.',
+    description: 'Descripción del curso.'
+  })
+  @MinLength(2, { message: 'La descripción debe tener mas de 2 caracteres.' })
+  @MaxLength(1000, { message: 'La descripción debe tener menos de 1000 caracteres.' })
+  @IsString({ message: 'La descripción debe ser un dato de tipo String.' })
+  @IsNotEmpty({ message: 'La descripción no debe estar vacía.' })
+  @Matches(/^[A-Za-zÁÉÍÓÚáéíóúÑñ0-9 .,:;()\-]+$/, {
+    message: 'La descripción solo puede contener letras, números y signos básicos',
+  })
   descripcion: string;
 
-  @ApiProperty({ 
-        example: '2025-05-31T05:11:55.496Z',
-        description: 'Fecha de creación del curso.'
-    })
-  @IsDate({message: 'La fecha de creación debe cumplir con el formato de la fecha.'})
+  @ApiProperty({
+    example: '2025-05-31T05:11:55.496Z',
+    description: 'Fecha de creación del curso.'
+  })
+  @IsDate({ message: 'La fecha de creación debe cumplir con el formato de la fecha.' })
   @IsOptional()
   @Type(() => Date)
   fechaCreacion: Date;
 
-  @ApiProperty({ 
-        example: '2025-05-31T05:11:55.496Z',
-        description: 'Fecha de inicio del curso.'
-    })
-  @IsDate({message: 'La fecha de inicio debe cumplir con el formato de la fecha.'})
+  @ApiProperty({
+    example: '2025-05-31T05:11:55.496Z',
+    description: 'Fecha de inicio del curso.'
+  })
+  @IsDate({ message: 'La fecha de inicio debe cumplir con el formato de la fecha.' })
   @IsOptional()
   @Type(() => Date)
   fechaInicio: Date;
 
-  @ApiProperty({ 
-        example: '2025-05-31T05:11:55.496Z',
-        description: 'Fecha de finalización del curso.'
-    })
-  @IsDate({message: 'La fecha final debe cumplir con el formato de la fecha.'})
+  @ApiProperty({
+    example: '2025-05-31T05:11:55.496Z',
+    description: 'Fecha de finalización del curso.'
+  })
+  @IsDate({ message: 'La fecha final debe cumplir con el formato de la fecha.' })
   @IsOptional()
   @Type(() => Date)
   fechaFinal: Date;
-  
-  @ApiProperty({ 
-        example: '250.90',
-        description: 'Precio del curso.'
-    })
-  @Min(0.0, {message: 'El precio debe ser mayor a 0.'})
-  @Max(12000000, {message: 'El precio debe ser menor a 12 millones.'})
-  @IsNumber({},{message: 'El precio debe ser un valor de tipo Number(Integer/Float/Decimal).'})
-  @IsNotEmpty({message: 'El precio no debe estar vacío.'})
-  @Transform(({ value }) => value !== null && value !== undefined ? parseFloat(String(value).trim()) : value)
+
+  @ApiProperty({
+    example: 250.90,
+    description: 'Precio del curso.'
+  })
+  @Min(0.0, { message: 'El precio debe ser mayor a 0.' })
+  @Max(12000000, { message: 'El precio debe ser menor a 12 millones.' })
+  @IsNumber({}, { message: 'El precio debe ser un valor de tipo Number(Integer/Float/Decimal).' })
+  @IsNotEmpty({ message: 'El precio no debe estar vacío.' })
+  @Transform(({ value }) =>
+    value !== null && value !== undefined
+      ? parseFloat(String(value).trim())
+      : value
+  )
   precio: number;
 
-  @ApiProperty({ 
-        example: 'true',
-        description: 'Estado del curso.'
-    })
+  @ApiProperty({
+    example: true,
+    description: 'Estado del curso.'
+  })
   @IsOptional()
-  @IsBoolean({message: 'El estado debe ser un valor de tipo boolean.'})
+  @IsBoolean({ message: 'El estado debe ser un valor de tipo boolean.' })
   estado: boolean;
 
-  @ApiProperty({ 
-        example: 'www.example.com/matematica_icono.png',
-        description: 'Imagen del curso.'
-    })
-  @MinLength(2, {message: 'La imagen debe tener mas de 1 carácter.'})
-  @MaxLength(250, {message: 'La imagen debe tener menos de 250 caracteres.'})
-  @IsString({message: 'La imagen debe ser un dato de tipo String.'})
-  @IsUrl({},{message: 'La imagen debe ser un URL.'})
-  @IsNotEmpty({message: 'La imagen no debe estar vacía.'})
+  @ApiProperty({
+    example: 'https://www.example.com/matematica_icono.png',
+    description: 'Imagen del curso.'
+  })
+  @MinLength(2, { message: 'La imagen debe tener mas de 1 carácter.' })
+  @MaxLength(250, { message: 'La imagen debe tener menos de 250 caracteres.' })
+  @IsString({ message: 'La imagen debe ser un dato de tipo String.' })
+  @IsUrl({}, { message: 'La imagen debe ser un URL.' })
+  @IsNotEmpty({ message: 'La imagen no debe estar vacía.' })
   @Transform(({ value }) => value.trim().replace(/\s+/g, ' '))
   imagen: string;
 
-  @ApiProperty({ 
-        example: '5.5',
-        description: 'Duración del curso medido por semanas.'
-    })
-  @Min(0.0, {message: 'La duración debe ser mayor a 0.'})
-  @Max(101.0, {message: 'La duración debe ser menor a 101.'})
-  @IsNumber({},{message: 'La duración debe ser un valor de tipo Number(Integer/Float/Decimal).'})
+  @ApiProperty({
+    example: 5.5,
+    description: 'Duración del curso medido por semanas.'
+  })
+  @Min(0.0, { message: 'La duración debe ser mayor a 0.' })
+  @Max(101.0, { message: 'La duración debe ser menor a 101.' })
+  @IsNumber({}, { message: 'La duración debe ser un valor de tipo Number(Integer/Float/Decimal).' })
   @IsOptional()
-  @Transform(({ value }) => value !== null && value !== undefined ? parseFloat(String(value).trim()) : value)
+  @Transform(({ value }) =>
+    value !== null && value !== undefined
+      ? parseFloat(String(value).trim())
+      : value
+  )
   duracionSemanas: number;
-  
-  @ApiProperty({ 
-        example: '64fd1c2f9a25d8e3f41b9c7a',
-        description: 'Id del profesor asignado al curso.'
-    })
-  @IsMongoId({message: 'profesorId debe ser MongoID.'})
-  @IsString({message: 'profesorId debe ser un dato de tipo String.'})
-  @IsNotEmpty({message: 'profesorId no debe estar vacío.'})
-  @Transform(({ value }) => (value as string).trim().toLowerCase().replaceAll(' ',''))
+
+  @ApiProperty({
+    example: '64fd1c2f9a25d8e3f41b9c7a',
+    description: 'Id del profesor asignado al curso.'
+  })
+  @IsMongoId({ message: 'profesorId debe ser MongoID.' })
+  @IsString({ message: 'profesorId debe ser un dato de tipo String.' })
+  @IsNotEmpty({ message: 'profesorId no debe estar vacío.' })
+  @Transform(({ value }) =>
+    (value as string).trim().toLowerCase().replaceAll(' ', '')
+  )
   profesorId: string;
 
-  @ApiProperty({ 
-        example: '5f43e9b5e3f1c530d8b6f8a9',
-        description: 'Id de la categoría asignada al curso.'
-    })
-  @IsMongoId({message: 'categoriaId debe ser MongoID.'})
-  @IsString({message: 'categoriaId debe ser un dato de tipo String.'})
-  @IsNotEmpty({message: 'categoriaId no debe estar vacío.'})
-  @Transform(({ value }) => (value as string).trim().toLowerCase().replaceAll(' ',''))
+  @ApiProperty({
+    example: '5f43e9b5e3f1c530d8b6f8a9',
+    description: 'Id de la categoría asignada al curso.'
+  })
+  @IsMongoId({ message: 'categoriaId debe ser MongoID.' })
+  @IsString({ message: 'categoriaId debe ser un dato de tipo String.' })
+  @IsNotEmpty({ message: 'categoriaId no debe estar vacío.' })
+  @Transform(({ value }) =>
+    (value as string).trim().toLowerCase().replaceAll(' ', '')
+  )
   categoriaId: string;
- @ApiProperty({
+
+  @ApiProperty({
     example: [
-      { titulo: 'Aprender sumas', descripcion: 'Sumar correctamente' },
+      { titulo: 'Aprender sumas', descripcion: 'Sumar correctamente' }
     ],
     description: 'Lista de beneficios del curso.',
     required: false,

--- a/src/infraestructure/persistence/curso/curso.prisma.repository.ts
+++ b/src/infraestructure/persistence/curso/curso.prisma.repository.ts
@@ -4,6 +4,7 @@ import { Curso } from 'src/core/entities/curso/curso.entity';
 import { CursoFactory } from 'src/core/fabricas/curso/curso.factory';
 import { CursoRepository } from 'src/core/repositories/curso/curso.respository';
 import { PrismaService } from 'src/core/services/prisma/prisma.service';
+import { ValidationError } from 'src/shared/domain/errors/validation.error';
 
 @Injectable()
 export class CursoPrismaRepository implements CursoRepository {
@@ -103,8 +104,72 @@ export class CursoPrismaRepository implements CursoRepository {
   }
 
   async save(curso: Curso): Promise<Curso> {
-    const data = await this.prisma.curso.create({
-      data: {
+    try {
+      const data = await this.prisma.curso.create({
+        data: {
+          nombre: curso.nombre,
+          descripcion: curso.descripcion,
+          beneficios: curso.beneficios,
+          fechaInicio: curso.fechaInicio,
+          fechaFinal: curso.fechaFinal,
+          precio: curso.precio,
+          estado: curso.estado,
+          imagen: curso.imagen,
+          duracionSemanas: curso.duracionSemanas,
+          profesor: {
+            connect: {
+              id: curso.profesorId,
+            },
+          },
+          categoria: {
+            connect: {
+              id: curso.categoriaId,
+            },
+          },
+        },
+        include: {
+          profesor: {
+            select: {
+              id: true,
+              nombre: true,
+              dni: false,
+              apellido_materno: true,
+              apellido_paterno: true,
+              estado_p: false,
+              email: true,
+            },
+          },
+          categoria: {
+            select: {
+              id: false,
+              nombre: true,
+              descripcion: true,
+              url: false,
+              estado: false,
+            },
+          },
+        },
+      });
+
+      return this.cursoFactory.crearDesdePrisma(data);
+    } catch (error) {
+      const mensaje = String(error);
+
+      if (mensaje.includes('Profesor') || mensaje.includes('CursoToProfesor')) {
+        throw new ValidationError('El profesor no existe');
+      }
+
+      if (mensaje.includes('Categoria') || mensaje.includes('CursoToCategoria')) {
+        throw new ValidationError('La categoría no existe');
+      }
+
+      throw new ValidationError('Error al registrar el curso');
+    }
+  }
+
+  async update(id: string, curso: Partial<Curso>): Promise<Curso> {
+    try {
+      const dataUpdate: Record<string, unknown> = {
         nombre: curso.nombre,
         descripcion: curso.descripcion,
         beneficios: curso.beneficios,
@@ -114,112 +179,79 @@ export class CursoPrismaRepository implements CursoRepository {
         estado: curso.estado,
         imagen: curso.imagen,
         duracionSemanas: curso.duracionSemanas,
+      };
 
-        profesor: {
+      if (curso.profesorId) {
+        dataUpdate.profesor = {
           connect: {
             id: curso.profesorId,
           },
-        },
-        categoria: {
+        };
+      }
+
+      if (curso.categoriaId) {
+        dataUpdate.categoria = {
           connect: {
             id: curso.categoriaId,
           },
-        },
-      },
-      include: {
-        profesor: {
-          select: {
-            id: true,
-            nombre: true,
-            dni: false,
-            apellido_materno: true,
-            apellido_paterno: true,
-            estado_p: false,
-            email: true,
+        };
+      }
+
+      const data = await this.prisma.curso.update({
+        where: { id },
+        data: dataUpdate,
+        include: {
+          profesor: {
+            select: {
+              id: true,
+              nombre: true,
+              dni: false,
+              apellido_materno: true,
+              apellido_paterno: true,
+              estado_p: false,
+              email: true,
+            },
+          },
+          categoria: {
+            select: {
+              id: false,
+              nombre: true,
+              descripcion: true,
+              url: false,
+              estado: false,
+            },
           },
         },
-        categoria: {
-          select: {
-            id: false,
-            nombre: true,
-            descripcion: true,
-            url: false,
-            estado: false,
-          },
-        },
-      },
-    });
+      });
 
-    return this.cursoFactory.crearDesdePrisma(data);
-  }
+      return this.cursoFactory.crearDesdePrisma(data);
+    } catch (error) {
+      const mensaje = String(error);
 
-  async update(id: string, curso: Partial<Curso>): Promise<Curso> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const dataUpdate: any = {
-      nombre: curso.nombre,
+      if (mensaje.includes('Profesor') || mensaje.includes('CursoToProfesor')) {
+        throw new ValidationError('El profesor no existe');
+      }
 
-      descripcion: curso.descripcion,
-      beneficios: curso.beneficios,
-      fechaInicio: curso.fechaInicio,
-      fechaFinal: curso.fechaFinal,
-      precio: curso.precio,
-      estado: curso.estado,
-      imagen: curso.imagen,
-      duracionSemanas: curso.duracionSemanas,
-    };
-    if (curso.profesorId) {
-      dataUpdate.profesor = {
-        connect: {
-          id: curso.profesorId,
-        },
-      };
+      if (mensaje.includes('Categoria') || mensaje.includes('CursoToCategoria')) {
+        throw new ValidationError('La categoría no existe');
+      }
+
+      throw new ValidationError('Error al actualizar el curso');
     }
-
-    if (curso.categoriaId) {
-      dataUpdate.categoria = {
-        connect: {
-          id: curso.categoriaId,
-        },
-      };
-    }
-
-    const data = await this.prisma.curso.update({
-      where: { id },
-      data: dataUpdate,
-      include: {
-        profesor: {
-          select: {
-            id: true,
-            nombre: true,
-            dni: false,
-            apellido_materno: true,
-            apellido_paterno: true,
-            estado_p: false,
-            email: true,
-          },
-        },
-        categoria: {
-          select: {
-            id: false,
-            nombre: true,
-            descripcion: true,
-            url: false,
-            estado: false,
-          },
-        },
-      },
-    });
-    return this.cursoFactory.crearDesdePrisma(data);
   }
 
   async delete(id: string, estado: boolean): Promise<Curso> {
-    const data = await this.prisma.curso.update({
-      where: { id },
-      data: {
-        estado: estado,
-      },
-    });
+    try {
+      const data = await this.prisma.curso.update({
+        where: { id },
+        data: {
+          estado,
+        },
+      });
 
-    return this.cursoFactory.crearDesdePrisma(data);
+      return this.cursoFactory.crearDesdePrisma(data);
+    } catch {
+      throw new ValidationError('El curso no existe o no se pudo eliminar');
+    }
   }
 }


### PR DESCRIPTION
Descripción

Se implementó el manejo de errores en el repositorio de cursos para evitar que los errores internos de Prisma se expongan directamente en la respuesta de la API. Ahora, cuando ocurre un problema relacionado con las relaciones de profesor o categoría al crear o actualizar un curso, el sistema captura el error y lo transforma en un error de dominio utilizando la clase ValidationError.

Además, se realizaron ajustes en el DTO de curso para mejorar las validaciones y asegurar que los datos enviados al repositorio cumplan con la estructura esperada.

Issue relacionada

Issue https://github.com/Dicta-Enterprise/back-nest-universo-dicta/issues/44

Cambios principales

Se agregó manejo de errores en curso.prisma.repository.ts utilizando try-catch.

Se transformaron los errores internos de Prisma en errores de dominio mediante la clase ValidationError.

Se implementaron mensajes de error más claros cuando el profesor o la categoría no existen.

Se realizaron ajustes en el DTO de curso para mejorar la validación de los datos recibidos.

Porque se hizo

Estos cambios se realizaron para mejorar el manejo de errores en la API, evitando que se expongan mensajes internos de Prisma y proporcionando respuestas más claras y controladas al cliente cuando ocurren problemas de validación o de relaciones en la base de datos.

<img width="1920" height="1080" alt="{FC8E359D-7486-4439-95CA-B166B38A6E7B}" src="https://github.com/user-attachments/assets/5933c6bd-f455-4e5c-9a21-da8df7012962" />
