### PR TITLE
feature: remover limite de paginacion por defecto en repositorio #63

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,6 +114,8 @@ model Planeta {
   galaxiaId          String         @db.ObjectId
   cursos             Curso[]
   landingPage        LandingPage[]
+  createdAt          DateTime?      @default(now()) @map("created_at")
+  updatedAt          DateTime?      @updatedAt      @map("updated_at")
 }
 
 type InfoPlaneta {

--- a/src/infraestructure/persistence/planeta/planeta.prisma.respository.ts
+++ b/src/infraestructure/persistence/planeta/planeta.prisma.respository.ts
@@ -100,7 +100,7 @@ export class PlanetaPrismaRepository implements PlanetaRepository {
       },
       include: galaxiaInclude,
       orderBy: {
-        nombre: 'asc',
+        createdAt: 'desc',
       },
     });
 

--- a/src/infraestructure/persistence/planeta/planeta.prisma.respository.ts
+++ b/src/infraestructure/persistence/planeta/planeta.prisma.respository.ts
@@ -91,11 +91,9 @@ export class PlanetaPrismaRepository implements PlanetaRepository {
   async findAllActive(
     planetaPaginationDto: PlanetaPaginationDto,
   ): Promise<Planeta[]> {
-    const { page, limit, galaxiaId } = planetaPaginationDto;
+    const { galaxiaId } = planetaPaginationDto;
 
     const planetas = await this.prisma.planeta.findMany({
-      skip: (page - 1) * limit,
-      take: limit,
       where: {
         estado: EstadoGenerico.ACTIVO,
         ...(galaxiaId && { galaxiaId }),


### PR DESCRIPTION
**Optimización de Repositorio de Planetas: Remoción de Límite y Ordenamiento Cronológico**
Este Pull Request aplica mejoras en el repositorio de persistencia del módulo de Planetas dentro del backend. Se elimina la restricción de paginación fija que limitaba la respuesta a solo 10 registros y se establece un ordenamiento por defecto para que los datos se entreguen organizados de forma cronológica descendente (desde el más reciente al más antiguo).
**Cambios Realizados**
Backend (back-nest-universo-dicta)
Repositorio de Prisma (src/infraestructure/persistence/planeta/planeta.prisma.respository.ts):
- Se removieron las cláusulas de paginación que truncaban el listado a un máximo de 10 registros. Ahora el endpoint retorna la totalidad de los planetas activos.

- Se incorporó la instrucción de ordenamiento orderBy dentro de la consulta a la base de datos utilizando el campo de auditoría, garantizando que la tabla del administrador reciba los registros organizados desde el más nuevo al más antiguo.

