### PR TITLE
feat: #65 implementar validacion de unicidad compuesta por nombre, categoria y galaxia

### DIFF
--- a/src/core/repositories/planeta/planeta.respository.ts
+++ b/src/core/repositories/planeta/planeta.respository.ts
@@ -5,7 +5,11 @@ import { Planeta } from 'src/core/entities/planeta/planeta.entity';
 export interface PlanetaRepository {
   findById(id: string): Promise<Planeta | null>;
   findByCodigo(codigo: string): Promise<Planeta | null>;
-  findByName(nombre: string): Promise<Planeta | null>;
+  findByNombreCategoriaYGalaxia(
+    nombre: string,
+    categoria: string,
+    galaxiaId: string,
+  ): Promise<Planeta | null>;
   findAllActive(planetaPaginationDto: PlanetaPaginationDto): Promise<Planeta[]>;
   save(planeta: Planeta): Promise<Planeta>;
   update(id: string, planeta: Partial<Planeta>): Promise<Planeta>;

--- a/src/core/services/planeta/planetas.service.ts
+++ b/src/core/services/planeta/planetas.service.ts
@@ -34,6 +34,25 @@ export class PlanetasService {
       );
     }
 
+    const planetaConNombreCategoriaGalaxia =
+      await this.repository.findByNombreCategoriaYGalaxia(
+        dtoPlaneta.nombre,
+        dtoPlaneta.categoria,
+        dtoPlaneta.galaxiaId,
+      );
+    if (planetaConNombreCategoriaGalaxia) {
+      throw new BussinesRuleException(
+        'El nombre del planeta ya se encuentra registrado en esta categoría y galaxia',
+        HttpStatus.CONFLICT,
+        {
+          nombre: dtoPlaneta.nombre,
+          categoria: dtoPlaneta.categoria,
+          galaxiaId: dtoPlaneta.galaxiaId,
+          codigoError: 'NOMBRE_CATEGORIA_GALAXIA_DUPLICADO',
+        },
+      );
+    }
+
     const galaxia = await this.galaxiasService.obtenerGalaxia(dtoPlaneta.galaxiaId);
 
     if (!galaxia) {
@@ -134,6 +153,34 @@ export class PlanetasService {
           {
             codigo: dtoPlaneta.codigo,
             codigoError: 'CODIGO_DUPLICADO',
+          },
+        );
+      }
+    }
+
+    if (
+      dtoPlaneta.nombre &&
+      dtoPlaneta.categoria &&
+      dtoPlaneta.galaxiaId &&
+      (dtoPlaneta.nombre !== planetaExistente.nombre ||
+        dtoPlaneta.categoria !== planetaExistente.categoria ||
+        dtoPlaneta.galaxiaId !== planetaExistente.galaxiaId)
+    ) {
+      const planetaConNombreCategoriaGalaxia =
+        await this.repository.findByNombreCategoriaYGalaxia(
+          dtoPlaneta.nombre,
+          dtoPlaneta.categoria,
+          dtoPlaneta.galaxiaId,
+        );
+      if (planetaConNombreCategoriaGalaxia) {
+        throw new BussinesRuleException(
+          'El nombre del planeta ya se encuentra registrado en esta categoría y galaxia',
+          HttpStatus.CONFLICT,
+          {
+            nombre: dtoPlaneta.nombre,
+            categoria: dtoPlaneta.categoria,
+            galaxiaId: dtoPlaneta.galaxiaId,
+            codigoError: 'NOMBRE_CATEGORIA_GALAXIA_DUPLICADO',
           },
         );
       }

--- a/src/infraestructure/http/planeta/planetas.controller.ts
+++ b/src/infraestructure/http/planeta/planetas.controller.ts
@@ -44,6 +44,11 @@ export class planetasController {
     status: 400,
     description: 'Datos inválidos o planeta duplicado.',
   })
+  @ApiResponse({
+    status: HttpStatus.CONFLICT,
+    description:
+      'Ya existe un planeta con el mismo nombre en esta categoría y galaxia.',
+  })
   async create(@Body() createDto: dto.CreatePlanetaDto) {
     const result = await this.createUseCase.execute(createDto);
 

--- a/src/infraestructure/persistence/planeta/planeta.prisma.respository.ts
+++ b/src/infraestructure/persistence/planeta/planeta.prisma.respository.ts
@@ -34,9 +34,17 @@ export class PlanetaPrismaRepository implements PlanetaRepository {
     return data ? this.planetaFactory.crearDesdePrisma(data) : null;
   }
 
-  async findByName(nombre: string): Promise<Planeta | null> {
+  async findByNombreCategoriaYGalaxia(
+    nombre: string,
+    categoria: string,
+    galaxiaId: string,
+  ): Promise<Planeta | null> {
     const data = await this.prisma.planeta.findFirst({
-      where: { nombre },
+      where: {
+        nombre,
+        categoria,
+        galaxiaId,
+      },
       include: galaxiaInclude,
     });
     return data ? this.planetaFactory.crearDesdePrisma(data) : null;


### PR DESCRIPTION
Se implementó la validación de unicidad compuesta en el backend para la creación y actualización de planetas, resolviendo la issue #65. Ahora el sistema impide el registro de planetas con nombres duplicados dentro de la misma Categoría y la misma Galaxia, permitiendo el mismo nombre únicamente si pertenecen a combinaciones (scopes) diferentes.
**Cambios realizados**
- **Repositorio (planeta.respository.ts):** Reemplazado el método simple findByName por el método compuesto findByNombreCategoriaYGalaxia.
- **Persistencia (planeta.prisma.respository.ts):** Implementada la consulta con Prisma filtrando por la combinación de { nombre, categoria, galaxiaId }.
- **Servicio (planetas.service.ts):** - Añadida validación iterativa en crearPlaneta que levanta una excepción controlada HTTP 400/409 si se repite la combinación.
  - Añadida lógica condicional de verificación en actualizarPlaneta que solo valida si los campos de unicidad compuesto sufren modificaciones.
- **Controlador (planetas.controller.ts):** Documentado el código HTTP 409 Conflict en Swagger con el decorador @ApiResponse.