### PR TITLE
feat: validacion obligatoria de peligros y beneficios #66

### DIFF
--- a/src/application/dto/planeta/create-planeta.dto.ts
+++ b/src/application/dto/planeta/create-planeta.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
+  ArrayMinSize,
   IsArray,
   IsEnum,
   IsMongoId,
@@ -124,13 +125,13 @@ export class CreatePlanetaDto {
     ],
     description: 'Lista de peligros del planeta',
     type: [PeligroDto],
-    required: false,
+    required: true,
   })
   @IsArray()
+  @ArrayMinSize(1, { message: 'El planeta debe tener al menos un peligro registrado' })
   @ValidateNested({ each: true })
   @Type(() => PeligroDto)
-  @IsOptional()
-  peligros?: PeligroDto[];
+  peligros: PeligroDto[];
 
   @ApiProperty({
     example: [
@@ -141,13 +142,13 @@ export class CreatePlanetaDto {
     ],
     description: 'Lista de beneficios del planeta',
     type: [BeneficioDto],
-    required: false,
+    required: true,
   })
   @IsArray()
+  @ArrayMinSize(1, { message: 'El planeta debe tener al menos un beneficio registrado' })
   @ValidateNested({ each: true })
   @Type(() => BeneficioDto)
-  @IsOptional()
-  beneficios?: BeneficioDto[];
+  beneficios: BeneficioDto[];
 
   @ApiProperty({
     example: '6997c5ad82bdf1267be250a6',

--- a/src/core/services/planeta/planetas.service.ts
+++ b/src/core/services/planeta/planetas.service.ts
@@ -22,6 +22,26 @@ export class PlanetasService {
   async crearPlaneta(dtoPlaneta: CreatePlanetaDto): Promise<Planeta> {
     await this.validator.validate(dtoPlaneta, CreatePlanetaDto);
 
+    if (!dtoPlaneta.peligros || dtoPlaneta.peligros.length === 0) {
+      throw new BussinesRuleException(
+        'El planeta debe tener al menos un peligro registrado',
+        HttpStatus.BAD_REQUEST,
+        {
+          codigoError: 'PELIGROS_VACIO',
+        },
+      );
+    }
+
+    if (!dtoPlaneta.beneficios || dtoPlaneta.beneficios.length === 0) {
+      throw new BussinesRuleException(
+        'El planeta debe tener al menos un beneficio registrado',
+        HttpStatus.BAD_REQUEST,
+        {
+          codigoError: 'BENEFICIOS_VACIO',
+        },
+      );
+    }
+
     const planetaExistente = await this.repository.findByCodigo(dtoPlaneta.codigo);
     if (planetaExistente) {
       throw new BussinesRuleException(


### PR DESCRIPTION
**Validacion obligatoria de peligros y beneficios**
Se realizo la integridad de los datos en el sistema impidiendo el registro de planetas "incompletos". Ahora es necesario que cualquier planeta registrado cuente obligatoriamente con al menos un peligro y un beneficio asociado.

**Para cumplir esto por completo, realizamos:**

1. **Se puso candado al formulario de entrada (DTO):**
   - Se hizo que los campos de peligros y beneficios dejen de ser opcionales; ahora el sistema los exige de manera obligatoria.
   - Les configuramos una regla para que, si el usuario los envía vacíos, el sistema los rechace de inmediato con mensajes claros:
     - *"El planeta debe tener al menos un peligro registrado"*
     - *"El planeta debe tener al menos un beneficio registrado"*

2. **Se reforzo la seguridad en el Servicio de Creación:**
   - Como segunda barrera de protección, se agrego una validación lógica directamente en el proceso de creación del planeta.
   - Si por alguna razón un registro intenta saltarse los filtros iniciales con listas vacías, el servicio detiene la operación en seco lanzando excepciones controladas (PELIGROS_VACIO y BENEFICIOS_VACIO), asegurando que nada incompleto llegue a la base de datos.